### PR TITLE
Adds tools for processing codelab sections and adds section markers f…

### DIFF
--- a/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
+++ b/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
@@ -86,6 +86,7 @@ class AppCommissioningService : Service(), CommissioningService.Callback {
             "port [${metadata.networkLocation.port}]\n" +
             "\tpassCode [${metadata.passcode}]")
 
+    // CODELAB: onCommissioningRequested()
     // Perform commissioning on custom fabric for the sample app.
     serviceScope.launch {
       val deviceId = devicesRepository.incrementAndReturnLastDeviceId()
@@ -122,5 +123,6 @@ class AppCommissioningService : Service(), CommissioningService.Callback {
           }
           .addOnFailureListener { ex -> Timber.w(ex, "Failed to send commissioning complete.") }
     }
+    // CODELAB SECTION END
   }
 }

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
@@ -93,6 +93,7 @@ class DeviceFragment : Fragment() {
     // at step 3 (in the viewModel) when the user triggers the "Share Device" action and the
     // Google Play Services (GPS) API (commissioningClient.shareDevice()) returns the IntentSender
     // to be used to launch the proper activity in GPS.
+    // CODELAB: shareDeviceLauncher definition
     shareDeviceLauncher =
         registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
           // Share Device Step 5.
@@ -105,6 +106,7 @@ class DeviceFragment : Fragment() {
             viewModel.shareDeviceFailed(getString(R.string.status_failed_with, resultCode))
           }
         }
+    // CODELAB SECTION END
   }
 
   override fun onCreateView(

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
@@ -96,6 +96,7 @@ constructor(
    * the sender again after a configuration change.
    */
   fun shareDevice(activity: FragmentActivity) {
+    // CODELAB: shareDevice
     _shareDeviceStatus.postValue(TaskStatus.InProgress)
     val shareDeviceRequest =
         ShareDeviceRequest.builder()
@@ -119,6 +120,7 @@ constructor(
           _shareDeviceIntentSender.postValue(result)
         }
         .addOnFailureListener { error -> _shareDeviceStatus.postValue(TaskStatus.Failed(error)) }
+    // CODELAB SECTION END
   }
 
   // Called by the fragment in Step 5 of the Device Sharing flow.
@@ -157,6 +159,7 @@ constructor(
         Timber.d("Handling test device")
         devicesStateRepository.updateDeviceState(deviceId, true, isOn)
       } else {
+        // CODELAB: toggle
         Timber.d("Handling real device")
         try {
           clustersHelper.setOnOffDeviceStateOnOffCluster(deviceUiModel.device.deviceId, isOn, 1)
@@ -164,6 +167,7 @@ constructor(
         } catch (e: Throwable) {
           Timber.e("Failed setting on/off state")
         }
+        // CODELAB SECTION END
       }
     }
   }

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
@@ -114,7 +114,9 @@ class HomeFragment : Fragment() {
 
   // The ActivityResult launcher that launches the "commissionDevice" activity in Google Play
   // Services.
+  // CODELAB: commissionDeviceLauncher declaration
   private lateinit var commissionDeviceLauncher: ActivityResultLauncher<IntentSenderRequest>
+  // CODELAB SECTION END
 
   // -----------------------------------------------------------------------------------------------
   // Lifecycle functions
@@ -128,6 +130,7 @@ class HomeFragment : Fragment() {
     // at step 2 (in the viewModel) when the user triggers the "Add Device" action and the
     // Google Play Services (GPS) API (commissioningClient.commissionDevice()) returns the
     // IntentSender to be used to launch the proper activity in GPS.
+    // CODELAB: commissionDeviceLauncher definition
     commissionDeviceLauncher =
         registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
           // Commission Device Step 5.
@@ -141,6 +144,7 @@ class HomeFragment : Fragment() {
             viewModel.commissionDeviceFailed(getString(R.string.status_failed_with, resultCode))
           }
         }
+    // CODELAB SECTION END
   }
 
   override fun onCreateView(
@@ -274,14 +278,17 @@ class HomeFragment : Fragment() {
     }
 
     // The current status of the share device action.
+    // CODELAB: commissionDeviceStatus
     viewModel.commissionDeviceStatus.observe(viewLifecycleOwner) { status ->
       Timber.d("commissionDeviceStatus.observe: status [${status}]")
       // TODO: disable the "add device button", update the result text view, etc.
     }
+    // CODELAB SECTION END
 
     // Commission Device Step 2.
     // The fragment observes the livedata for commissionDeviceIntentSender which
     // is updated in the ViewModel in step 3 of the Commission Device flow.
+    // CODELAB: commissionDeviceIntentSender
     viewModel.commissionDeviceIntentSender.observe(viewLifecycleOwner) { sender ->
       Timber.d("commissionDeviceIntentSender.observe is called with sender [${sender}]")
       if (sender != null) {
@@ -292,6 +299,7 @@ class HomeFragment : Fragment() {
         commissionDeviceLauncher.launch(IntentSenderRequest.Builder(sender).build())
       }
     }
+    // CODELAB SECTION END
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -174,6 +174,7 @@ constructor(
    * After using the sender, [consumeCommissionDeviceIntentSender()] should be called to avoid
    * receiving the sender again after a configuration change.
    */
+  // CODELAB: commissionDevice
   fun commissionDevice(intent: Intent, context: Context) {
     Timber.d("commissionDevice")
     _commissionDeviceStatus.postValue(TaskStatus.InProgress)
@@ -212,6 +213,7 @@ constructor(
           Timber.e(error)
         }
   }
+  // CODELAB SECTION END
 
   /** Consumes the value in [_commissionDeviceIntentSender] and sets it back to null. */
   fun consumeCommissionDeviceIntentSender() {

--- a/tools/process-codelab-source-file.py
+++ b/tools/process-codelab-source-file.py
@@ -1,0 +1,46 @@
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Called by the script process-codelab-source-files.sh.
+# Argument is the path to the source file to process.
+
+import re
+import sys
+
+if len(sys.argv) < 2:
+    sys.exit("Error: Please specify the name of the file to process.")
+
+file = sys.argv[1]
+
+codelabStartPattern = '// CODELAB: '
+codelabEndPattern = '// CODELAB SECTION END'
+
+lines = []
+
+with open(file, 'rt') as infile:
+    discard = False
+    for line in infile:
+        if discard:
+          if codelabEndPattern in line:
+            discard = False
+        else:
+          lines.append(line)
+          if codelabStartPattern in line:
+                discard = True
+
+with open(file, 'w') as outfile:
+    for line in lines:
+        outfile.write(line)

--- a/tools/process-codelab-source-files.sh
+++ b/tools/process-codelab-source-files.sh
@@ -1,0 +1,56 @@
+#/bin/sh
+
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Gets the name of all the files that have at least one codelab section
+# and invokes the script process-codelab-source-file.py to remove the
+# code from the codelab sections.
+#
+# Arguments
+#   1. repoRootPath [optional]
+#      Path to the root of the sample app repo.
+#      If not specified, defaults to the directory where the command is run.
+#
+# Sample usage:
+#   If at the root of the sample app repo:
+#      ./tools/process-codelab-source-files.sh
+#   From anywhere:
+#      <repoRootPath>/tools/process-codelab-source-files.sh <repoRootPath>
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+if [ $# -eq 0 ]
+then
+  root=`pwd`
+elif [ $# -eq 1 ]
+then
+  root=$1
+else
+  echo "Error: Usage is $0 [repoRootPath]"
+  exit 1
+fi
+
+echo "root [$root]"
+
+for file in $(grep -rFl --include "*.kt" "// CODELAB: ")
+do
+  realFilePath=`realpath $file`
+  echo "Processing $realFilePath ..."
+  python3 ${root}/tools/process-codelab-source-file.py $realFilePath
+done


### PR DESCRIPTION
…or codelab code.

Sections markers for codelab sections are identified as follows: Beginning of codelab section:
  // CODELAB: <section info>
End of codelab section:
  // CODELAB SECTION END

Thanks to these codelab section markers, we can run the script tools/process-codelab-source-files.sh (which calls tools/process-codelab-source-file.py) to easily update the codelab branch so it only has the codelab comment without the actual code.