### PR TITLE
Fixes for proper error handling on calls to the Matter SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,13 @@ download the correct one for your use case.
 
 ## Get started
 
-*   To make sure that your device has the latest Matter support, review the
+* Check the presentation "Building Smart Home Apps with the Google Home Mobile SDK"
+    (docs/GoogleHomeMobileSDK.pdf) for an overview of the Sample App and key APIs
+    of the Mobile SDK.
+* To make sure that your device has the latest Matter support, review the
     [Verify Matter Modules & Services](https://developers.home.google.com/matter/verify-services)
     guide.
-*   Build a Matter device with On/Off capabilities. This sample  app works with a virtual device
+* Build a Matter device with On/Off capabilities. This sample  app works with a virtual device
     and an ESP32.
     *   [Build a Matter Virtual Device](https://developers.home.google.com/codelabs/matter-device-virtual)
         with the `rootnode_dimmablelight_bCwGYSDpoe` app. When you
@@ -77,11 +80,11 @@ download the correct one for your use case.
         [Create a Matter integration](https://developers.home.google.com/matter/integration/create)
         in the [Home Developer Console](https://console.home.google.com/projects),
         use `0xFFF1` as your Vendor ID and `0x8001` as your Product ID.
-*   For an overview of the user interface and features, refer to
+* For an overview of the user interface and features, refer to
     the [Google Home Sample App for Matter Guide](https://developers.home.google.com/samples/matter-app).
-*   To review code samples and start building, refer to
+* To review code samples and start building, refer to
     the [Build an Android App for Matter](https://developers.home.google.com/codelabs/matter-sample-app)
-    Codelab.        
+    Codelab.
 
 ## Version
 

--- a/app/src/main/java/com/google/homesampleapp/GHSAFMApplication.kt
+++ b/app/src/main/java/com/google/homesampleapp/GHSAFMApplication.kt
@@ -42,7 +42,5 @@ class GHSAFMApplication : Application() {
            * "%s:%s", super.createStackElementTag(element), element.methodName, ) }
            */
         })
-
-    Timber.d("GHSAFM application created!")
   }
 }

--- a/app/src/main/java/com/google/homesampleapp/MainActivity.kt
+++ b/app/src/main/java/com/google/homesampleapp/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil.setContentView
 import com.google.homesampleapp.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 /** Main Activity for the "Google Home Sample App for Matter" (GHSAFM). */
 @AndroidEntryPoint
@@ -30,12 +31,12 @@ class MainActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    initContextDependentConstants()
+
     binding = setContentView(this, R.layout.activity_main)
 
     // Useful to see which preferences are set under the hood by Matter libraries.
     displayPreferences(this)
-
-    initContextDependentConstants()
   }
 
   /**
@@ -46,6 +47,9 @@ class MainActivity : AppCompatActivity() {
     // versionName is set in build.gradle.
     val packageInfo = packageManager.getPackageInfo(packageName, 0)
     VERSION_NAME = packageInfo.versionName
+    Timber.i(
+        "==============================\nVersion ${VERSION_NAME}\n" +
+            "==============================")
 
     // Strings associated with DeviceTypes
     setDeviceTypeStrings(

--- a/app/src/main/java/com/google/homesampleapp/Utils.kt
+++ b/app/src/main/java/com/google/homesampleapp/Utils.kt
@@ -47,13 +47,13 @@ sealed class TaskStatus {
    * The task completed with an exception.
    * @param cause the cause of the failure
    */
-  class Failed(private val cause: Throwable) : TaskStatus()
+  class Failed(val message: String, val cause: Throwable) : TaskStatus()
 
   /**
    * The task completed successfully.
    * @param statusMessage a message to be displayed in the UI
    */
-  class Completed(private val statusMessage: String) : TaskStatus()
+  class Completed(val statusMessage: String) : TaskStatus()
 }
 
 /** Useful when investigating lifecycle events in logcat. */

--- a/app/src/main/java/com/google/homesampleapp/Utils.kt
+++ b/app/src/main/java/com/google/homesampleapp/Utils.kt
@@ -56,6 +56,15 @@ sealed class TaskStatus {
   class Completed(val statusMessage: String) : TaskStatus()
 }
 
+/** Enumeration of actions to take a background work alert dialog. */
+sealed class BackgroundWorkAlertDialogAction {
+  /** Background work has started, show the dialog. */
+  class Show(val title: String, val message: String) : BackgroundWorkAlertDialogAction()
+
+  /** Background work has completed, hide the dialog. */
+  object Hide : BackgroundWorkAlertDialogAction()
+}
+
 /** Useful when investigating lifecycle events in logcat. */
 fun lifeCycleEvent(event: String): String {
   return "[*** LifeCycle ***] $event"

--- a/app/src/main/java/com/google/homesampleapp/chip/BaseCompletionListener.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/BaseCompletionListener.kt
@@ -25,39 +25,40 @@ import timber.log.Timber
  */
 abstract class BaseCompletionListener : ChipDeviceController.CompletionListener {
   override fun onConnectDeviceComplete() {
-    Timber.d("onConnectDeviceComplete()")
+    Timber.d("BaseCompletionListener onConnectDeviceComplete()")
   }
 
   override fun onStatusUpdate(status: Int) {
-    Timber.d("onStatusUpdate(): status [${status}]")
+    Timber.d("BaseCompletionListener onStatusUpdate(): status [${status}]")
   }
 
   override fun onPairingComplete(code: Int) {
-    Timber.d("onPairingComplete(): code [${code}]")
+    Timber.d("BaseCompletionListener onPairingComplete(): code [${code}]")
   }
 
   override fun onPairingDeleted(code: Int) {
-    Timber.d("onPairingDeleted(): code [${code}]")
+    Timber.d("BaseCompletionListener onPairingDeleted(): code [${code}]")
   }
 
   override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
-    Timber.d("onCommissioningComplete(): nodeId [${nodeId}] errorCode [${errorCode}]")
+    Timber.d(
+        "BaseCompletionListener onCommissioningComplete(): nodeId [${nodeId}] errorCode [${errorCode}]")
   }
 
   override fun onNotifyChipConnectionClosed() {
-    Timber.d("onNotifyChipConnectionClosed()")
+    Timber.d("BaseCompletionListener onNotifyChipConnectionClosed()")
   }
 
   override fun onCloseBleComplete() {
-    Timber.d("onCloseBleComplete()")
+    Timber.d("BaseCompletionListener onCloseBleComplete()")
   }
 
   override fun onError(error: Throwable) {
-    Timber.e(error, "onError()")
+    Timber.e(error, "BaseCompletionListener onError()")
   }
 
   override fun onOpCSRGenerationComplete(csr: ByteArray) {
-    Timber.d("onOpCSRGenerationComplete(): csr [${csr}]")
+    Timber.d("BaseCompletionListener onOpCSRGenerationComplete() csr [${csr}]")
   }
 
   override fun onReadCommissioningInfo(

--- a/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
+++ b/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
@@ -22,13 +22,10 @@ import android.os.IBinder
 import com.google.android.gms.home.matter.commissioning.CommissioningCompleteMetadata
 import com.google.android.gms.home.matter.commissioning.CommissioningRequestMetadata
 import com.google.android.gms.home.matter.commissioning.CommissioningService
-import com.google.homesampleapp.Device
 import com.google.homesampleapp.chip.ChipClient
 import com.google.homesampleapp.chip.ClustersHelper
-import com.google.homesampleapp.convertToAppDeviceType
 import com.google.homesampleapp.data.DevicesRepository
 import com.google.homesampleapp.data.DevicesStateRepository
-import com.google.homesampleapp.getTimestampForNow
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -90,38 +87,27 @@ class AppCommissioningService : Service(), CommissioningService.Callback {
     // Perform commissioning on custom fabric for the sample app.
     serviceScope.launch {
       val deviceId = devicesRepository.incrementAndReturnLastDeviceId()
-      Timber.d("Commissioning Step 1: ChipClient.establishPaseConnection(): deviceId [${deviceId}]")
+      Timber.d(
+          "Commissioning: App fabric -> ChipClient.establishPaseConnection(): deviceId [${deviceId}]")
       chipClient.awaitEstablishPaseConnection(
           deviceId,
           metadata.networkLocation.ipAddress.hostAddress!!,
           metadata.networkLocation.port,
           metadata.passcode)
-      Timber.d("Commissioning Step 2: ChipClient.commissionDevice(): deviceId [${deviceId}]")
+      Timber.d("Commissioning: App fabric -> ChipClient.commissionDevice(): deviceId [${deviceId}]")
       chipClient.awaitCommissionDevice(deviceId, null)
 
-      Timber.d("Commissioning Step 3: Adding device to repository")
-      devicesRepository.addDevice(
-          Device.newBuilder()
-              .setName("REAL-$deviceId") // default name that can be overridden by user in next step
-              .setDeviceId(deviceId)
-              .setDateCommissioned(getTimestampForNow())
-              .setVendorId(metadata.deviceDescriptor.vendorId.toString())
-              .setProductId(metadata.deviceDescriptor.productId.toString())
-              .setDeviceType(convertToAppDeviceType(metadata.deviceDescriptor.deviceType))
-              .build())
-
-      Timber.d("Commissioning Step 4: Adding device state to repository: isOnline:true isOn:false")
-      devicesStateRepository.addDeviceState(deviceId, isOnline = true, isOn = false)
-
-      Timber.d(
-          "Commissioning Step 5: Calling commissioningServiceDelegate.sendCommissioningComplete()")
+      Timber.d("Commissioning: Calling commissioningServiceDelegate.sendCommissioningComplete()")
       commissioningServiceDelegate
           .sendCommissioningComplete(
               CommissioningCompleteMetadata.builder().setToken(deviceId.toString()).build())
           .addOnSuccessListener {
-            Timber.d("OnSuccess for commissioningServiceDelegate.sendCommissioningComplete()")
+            Timber.d(
+                "Commissioning: OnSuccess for commissioningServiceDelegate.sendCommissioningComplete()")
           }
-          .addOnFailureListener { ex -> Timber.w(ex, "Failed to send commissioning complete.") }
+          .addOnFailureListener { ex ->
+            Timber.e("Commissioning: Failed to send commissioning complete.", ex)
+          }
     }
     // CODELAB SECTION END
   }

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
@@ -36,6 +36,7 @@ import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.homesampleapp.ALLOW_DEVICE_SHARING_ON_DUMMY_DEVICE
+import com.google.homesampleapp.BackgroundWorkAlertDialogAction
 import com.google.homesampleapp.DeviceState
 import com.google.homesampleapp.ON_OFF_SWITCH_DISABLED_WHEN_DEVICE_OFFLINE
 import com.google.homesampleapp.PERIODIC_UPDATE_INTERVAL_DEVICE_SCREEN_SECONDS
@@ -81,6 +82,9 @@ class DeviceFragment : Fragment() {
 
   // The Activity launcher that launches the "shareDevice" activity in Google Play Services.
   private lateinit var shareDeviceLauncher: ActivityResultLauncher<IntentSenderRequest>
+
+  // Background work dialog.
+  private lateinit var backgroundWorkAlertDialog: AlertDialog
 
   // Error alert dialog.
   private lateinit var errorAlertDialog: AlertDialog
@@ -151,6 +155,9 @@ class DeviceFragment : Fragment() {
   // Setup UI elements
 
   private fun setupUiElements() {
+    // Bacjkground Work AlertDialog
+    backgroundWorkAlertDialog = MaterialAlertDialogBuilder(requireContext()).create()
+
     // Error AlertDialog
     errorAlertDialog =
         MaterialAlertDialogBuilder(requireContext())
@@ -241,6 +248,20 @@ class DeviceFragment : Fragment() {
     }
   }
 
+  private fun showBackgroundWorkAlertDialog(title: String?, message: String?) {
+    if (title != null) {
+      backgroundWorkAlertDialog.setTitle(title)
+    }
+    if (message != null) {
+      backgroundWorkAlertDialog.setMessage(message)
+    }
+    backgroundWorkAlertDialog.show()
+  }
+
+  private fun hideBackgroundWorkAlertDialog() {
+    backgroundWorkAlertDialog.hide()
+  }
+
   private fun showErrorAlertDialog(title: String?, message: String?) {
     if (title != null) {
       errorAlertDialog.setTitle(title)
@@ -272,6 +293,15 @@ class DeviceFragment : Fragment() {
       updateShareDeviceButton(isButtonEnabled)
       if (status is TaskStatus.Failed) {
         showErrorAlertDialog(status.message, status.cause.toString())
+      }
+    }
+
+    // Background work alert dialog actions.
+    viewModel.backgroundWorkAlertDialogAction.observe(viewLifecycleOwner) { action ->
+      if (action is BackgroundWorkAlertDialogAction.Show) {
+        showBackgroundWorkAlertDialog(action.title, action.message)
+      } else if (action is BackgroundWorkAlertDialogAction.Hide) {
+        hideBackgroundWorkAlertDialog()
       }
     }
 

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
@@ -19,7 +19,10 @@ package com.google.homesampleapp.screens.device
 import android.content.IntentSender
 import android.os.SystemClock
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.android.gms.home.matter.Matter
 import com.google.android.gms.home.matter.commissioning.CommissioningWindow
 import com.google.android.gms.home.matter.commissioning.ShareDeviceRequest
@@ -27,7 +30,9 @@ import com.google.android.gms.home.matter.common.DeviceDescriptor
 import com.google.android.gms.home.matter.common.Discriminator
 import com.google.homesampleapp.DISCRIMINATOR
 import com.google.homesampleapp.ITERATION
+import com.google.homesampleapp.OPEN_COMMISSIONING_WINDOW_API
 import com.google.homesampleapp.OPEN_COMMISSIONING_WINDOW_DURATION_SECONDS
+import com.google.homesampleapp.OpenCommissioningWindowApi
 import com.google.homesampleapp.PERIODIC_UPDATE_INTERVAL_DEVICE_SCREEN_SECONDS
 import com.google.homesampleapp.SETUP_PIN_CODE
 import com.google.homesampleapp.TaskStatus
@@ -59,95 +64,109 @@ constructor(
   // Controls whether a periodic ping to the device is enabled or not.
   private var devicePeriodicPingEnabled: Boolean = true
 
-  /** The current status of the share device action sent via [shareDevice]. */
+  /**
+   * The current status of the share device task. The enum it is based on is used by the Fragment to
+   * properly react to the processing happening with the share device task.
+   */
   private val _shareDeviceStatus = MutableLiveData<TaskStatus>(TaskStatus.NotStarted)
   val shareDeviceStatus: LiveData<TaskStatus>
     get() = _shareDeviceStatus
 
-  /** Generic status about actions processed in this screen. */
-  private val _statusInfo = MutableLiveData("")
-  val statusInfo: LiveData<String>
-    get() = _statusInfo
-
-  /**
-   * Device Sharing Step 1. Setup the LiveData that holds the IntentSender used to trigger Device
-   * Sharing. The IntentSender is returned when calling the shareDevice() API of Google Play
-   * Services (GPS) when a Device Sharing flow is initiated in Step 3. An observer of that
-   * IntentSender is setup in Step 2.
-   */
+  /** IntentSender LiveData. */
   private val _shareDeviceIntentSender = MutableLiveData<IntentSender?>()
   val shareDeviceIntentSender: LiveData<IntentSender?>
     get() = _shareDeviceIntentSender
 
   // -----------------------------------------------------------------------------------------------
-  // Device Sharing
+  // Device Sharing (aka Multi-Admin)
+  //
+  // See "docs/Google Home Mobile SDK.pdf" for a good overview of all the artifacts needed
+  // to transfer control from the sample app's UI to the GPS ShareDevice UI, and get a result back.
 
   /**
-   * Share Device Step 3. Initiates a share device task. The success callback of the
-   * commissioningClient.shareDevice() API provides the IntentSender to be used to launch the
-   * "ShareDevice" activity in Google Play Services. This viewModel provides two LiveData objects to
-   * report on the result of this API call that can then be used by the Fragment who's observing
-   * them:
-   * 1. [shareDeviceStatus] reports the result of the call which is displayed in the fragment
-   * 2. [shareDeviceIntentSender] is the result of the shareDevice() call that can then be used in
-   * the Fragment to launch the Google Play Services "Share Device" activity.
+   * ShareDevice triggered by the button in the Fragment.
    *
-   * After using the sender, [consumeShareDeviceIntentSender] should be called to avoid receiving
-   * the sender again after a configuration change.
+   * TODO: (to be clarified) After using the sender, [consumeShareDeviceIntentSender] should be
+   * called to avoid receiving the sender again after a configuration change.
    */
-  fun shareDevice(activity: FragmentActivity) {
-    // CODELAB: shareDevice
+  fun shareDevice(activity: FragmentActivity, deviceId: Long) {
+    Timber.d("ShareDevice: starting")
+
+    stopDevicePeriodicPing()
+
     _shareDeviceStatus.postValue(TaskStatus.InProgress)
-    val shareDeviceRequest =
-        ShareDeviceRequest.builder()
-            .setDeviceDescriptor(DeviceDescriptor.builder().build())
-            .setDeviceName("temp device name")
-            .setCommissioningWindow(
-                CommissioningWindow.builder()
-                    .setDiscriminator(Discriminator.forLongValue(123))
-                    .setPasscode(11223344)
-                    .setWindowOpenMillis(SystemClock.elapsedRealtime())
-                    .setDurationSeconds(180)
-                    .build())
-            .build()
-
-    Matter.getCommissioningClient(activity)
-        .shareDevice(shareDeviceRequest)
-        .addOnSuccessListener { result ->
-          Timber.d("Success on CommissioningClient.shareDevice(): result [${result}]")
-          // Communication with fragment is via livedata
-          _shareDeviceStatus.postValue(TaskStatus.Completed("Received IntentSender."))
-          _shareDeviceIntentSender.postValue(result)
+    viewModelScope.launch {
+      // First we need to open a commissioning window.
+      try {
+        when (OPEN_COMMISSIONING_WINDOW_API) {
+          OpenCommissioningWindowApi.ChipDeviceController ->
+              openCommissioningWindowUsingOpenPairingWindowWithPin(deviceId)
+          OpenCommissioningWindowApi.AdministratorCommissioningCluster ->
+              openCommissioningWindowWithAdministratorCommissioningCluster(deviceId)
         }
-        .addOnFailureListener { error -> _shareDeviceStatus.postValue(TaskStatus.Failed(error)) }
-    // CODELAB SECTION END
+      } catch (e: Throwable) {
+        val msg = "Failed to open the commissioning window"
+        Timber.d("ShareDevice: ${msg} [${e}]")
+        _shareDeviceStatus.postValue(TaskStatus.Failed(msg, e))
+        return@launch
+      }
+
+      // Second, we get the IntentSender and post it as LiveData for the fragment to pick it up
+      // and trigger the GPS ShareDevice activity.
+      // CODELAB: shareDevice
+      Timber.d("ShareDevice: Setting up the IntentSender")
+      val shareDeviceRequest =
+          ShareDeviceRequest.builder()
+              .setDeviceDescriptor(DeviceDescriptor.builder().build())
+              .setDeviceName("temp device name")
+              .setCommissioningWindow(
+                  CommissioningWindow.builder()
+                      .setDiscriminator(Discriminator.forLongValue(DISCRIMINATOR))
+                      .setPasscode(SETUP_PIN_CODE)
+                      .setWindowOpenMillis(SystemClock.elapsedRealtime())
+                      .setDurationSeconds(OPEN_COMMISSIONING_WINDOW_DURATION_SECONDS.toLong())
+                      .build())
+              .build()
+
+      Matter.getCommissioningClient(activity)
+          .shareDevice(shareDeviceRequest)
+          .addOnSuccessListener { result ->
+            Timber.d("ShareDevice: Success getting the IntentSender: result [${result}]")
+            if (result == null) {
+              _shareDeviceStatus.postValue(
+                  TaskStatus.Failed(
+                      "Failed to get the IntentSender", error("Null value for IntentSender")))
+            } else {
+              // Communication with fragment is via livedata
+              _shareDeviceIntentSender.postValue(result)
+            }
+          }
+          .addOnFailureListener { error ->
+            _shareDeviceStatus.postValue(
+                TaskStatus.Failed("Setting up the IntentSender failed", error))
+          }
+      // CODELAB SECTION END
+    }
   }
 
-  // Called by the fragment in Step 5 of the Device Sharing flow.
-  fun shareDeviceSucceeded(message: String) {
-    _shareDeviceStatus.postValue(TaskStatus.Completed(message))
-  }
-
-  // Called by the fragment in Step 5 of the Device Sharing flow.
-  fun shareDeviceFailed(message: String) {
-    _shareDeviceStatus.postValue(TaskStatus.Failed(Throwable(message)))
-  }
-
+  // TODO: Test this to clearly understand and document the motivation to do this.
   /** Consumes the value in [shareDeviceIntentSender] and sets it back to null. */
   private fun consumeShareDeviceIntentSender() {
     _shareDeviceIntentSender.postValue(null)
   }
 
-  /** Updates the status of [shareDeviceStatus] to success with the given message. */
-  fun setSharingCompletedStatusText(text: String) {
-    _shareDeviceStatus.postValue(TaskStatus.Completed(text))
+  // Called by the fragment when the GPS activity for Device Sharing has completed.
+  // Do cleanup tasks.
+  fun shareDeviceCompleted(deviceUiModel: DeviceUiModel) {
+    startDevicePeriodicPing(deviceUiModel)
   }
 
   // -----------------------------------------------------------------------------------------------
   // Operations on device
 
   fun removeDevice(deviceId: Long) {
-    Timber.d("**************** remove device ****** [${deviceId}]")
+    Timber.d("Removing device [${deviceId}]")
+    // TODO: send message to device to unlink.
     viewModelScope.launch { devicesRepository.removeDevice(deviceId) }
   }
 
@@ -238,39 +257,38 @@ constructor(
   // -----------------------------------------------------------------------------------------------
   // Open commissioning window
 
-  fun openCommissioningWindowUsingOpenPairingWindowWithPin(deviceId: Long) {
-    viewModelScope.launch {
-      Timber.d("BEGIN openCommissioningWindowUsingOpenPairingWindowWithPin")
-      // TODO: Should generate random 64 bit value
-      Timber.d("*** calling chipClient.awaitGetDeviceBeingCommissionedPointer ***")
-      val connectedDevicePointer = chipClient.awaitGetConnectedDevicePointer(deviceId)
-      Timber.d("Calling chipClient.awaitOpenPairingWindowWithPIN")
-      val duration = OPEN_COMMISSIONING_WINDOW_DURATION_SECONDS
-      chipClient.awaitOpenPairingWindowWithPIN(
-          connectedDevicePointer, duration, ITERATION, DISCRIMINATOR, SETUP_PIN_CODE)
-      Timber.d("END openCommissioningWindowUsingOpenPairingWindowWithPin")
-    }
+  suspend fun openCommissioningWindowUsingOpenPairingWindowWithPin(deviceId: Long) {
+    // TODO: Should generate random 64 bit value
+    Timber.d("ShareDevice: chipClient.awaitGetConnectedDevicePointer(${deviceId})")
+    val connectedDevicePointer = chipClient.awaitGetConnectedDevicePointer(deviceId)
+    val duration = OPEN_COMMISSIONING_WINDOW_DURATION_SECONDS
+    Timber.d(
+        "ShareDevice: chipClient.chipClient.awaitOpenPairingWindowWithPIN " +
+            "duration [${duration}] iteration [${ITERATION}] discriminator [${DISCRIMINATOR}] " +
+            "setupPinCode [${SETUP_PIN_CODE}]")
+    chipClient.awaitOpenPairingWindowWithPIN(
+        connectedDevicePointer, duration, ITERATION, DISCRIMINATOR, SETUP_PIN_CODE)
+    Timber.d("ShareDevice: After chipClient.awaitOpenPairingWindowWithPIN")
   }
 
   // TODO: Was not working when tested. Use openCommissioningWindowUsingOpenPairingWindowWithPin
   // for now.
-  fun openCommissioningWindowWithAdministratorCommissioningCluster(deviceId: Long) {
-    viewModelScope.launch {
-      Timber.d("openCommissioningWindowWithAdministratorCommissioningCluster [${deviceId}]")
-      val salt = Random.nextBytes(32)
-      val timedInvokeTimeoutMs = 10000
-      val devicePtr = chipClient.awaitGetConnectedDevicePointer(deviceId)
-      val verifier = chipClient.computePaseVerifier(devicePtr, SETUP_PIN_CODE, ITERATION, salt)
-      clustersHelper.openCommissioningWindowAdministratorCommissioningCluster(
-          deviceId,
-          0,
-          180,
-          verifier.pakeVerifier,
-          DISCRIMINATOR,
-          ITERATION,
-          salt,
-          timedInvokeTimeoutMs)
-    }
+  suspend fun openCommissioningWindowWithAdministratorCommissioningCluster(deviceId: Long) {
+    Timber.d(
+        "ShareDevice: openCommissioningWindowWithAdministratorCommissioningCluster [${deviceId}]")
+    val salt = Random.nextBytes(32)
+    val timedInvokeTimeoutMs = 10000
+    val devicePtr = chipClient.awaitGetConnectedDevicePointer(deviceId)
+    val verifier = chipClient.computePaseVerifier(devicePtr, SETUP_PIN_CODE, ITERATION, salt)
+    clustersHelper.openCommissioningWindowAdministratorCommissioningCluster(
+        deviceId,
+        0,
+        180,
+        verifier.pakeVerifier,
+        DISCRIMINATOR,
+        ITERATION,
+        salt,
+        timedInvokeTimeoutMs)
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -222,7 +222,7 @@ constructor(
   }
 
   // Called by the fragment in Step 5 of the Device Commissioning flow.
-  fun commissionDeviceSucceeded(activityResult: ActivityResult, message: String) {
+  fun commissionDeviceSucceeded(activityResult: ActivityResult, deviceName: String) {
     val result =
         CommissioningResult.fromIntentSenderResult(activityResult.resultCode, activityResult.data)
     Timber.i("Device commissioned successfully! deviceName [${result.deviceName}]")
@@ -234,25 +234,31 @@ constructor(
             "vendorId [${result.commissionedDeviceDescriptor.vendorId}]\n" +
             "hashCode [${result.commissionedDeviceDescriptor.hashCode()}]")
 
-    // Update the data in the devices repository.
+    // Add the device to the devices repository.
     viewModelScope.launch {
+      val deviceId = result.token?.toLong()!!
       try {
-        val deviceId = result.token?.toLong()!!
-        val currentDevice: Device = devicesRepository.getDevice(deviceId)
-        val roomName =
-            result.room?.name // needed 'cause smartcast impossible with open/custom getter
-        val updatedDeviceBuilder =
-            Device.newBuilder(currentDevice)
+        Timber.d("Commissioning: Adding device to repository")
+        devicesRepository.addDevice(
+            Device.newBuilder()
+                .setName(deviceName) // default name that can be overridden by user in next step
+                .setDeviceId(deviceId)
+                .setDateCommissioned(getTimestampForNow())
+                .setVendorId(result.commissionedDeviceDescriptor.vendorId.toString())
+                .setProductId(result.commissionedDeviceDescriptor.productId.toString())
+                // FIXME check this --> I always have unknown
                 .setDeviceType(
                     convertToAppDeviceType(result.commissionedDeviceDescriptor.deviceType))
-                .setProductId(result.commissionedDeviceDescriptor.productId.toString())
-                .setVendorId(result.commissionedDeviceDescriptor.vendorId.toString())
-        if (result.deviceName != null) updatedDeviceBuilder.name = result.deviceName
-        if (roomName != null) updatedDeviceBuilder.room = roomName
-        devicesRepository.updateDevice(updatedDeviceBuilder.build())
-        _commissionDeviceStatus.postValue(TaskStatus.Completed(message))
+                .build())
+        Timber.d("Commissioning: Adding device state to repository: isOnline:true isOn:false")
+        devicesStateRepository.addDeviceState(deviceId, isOnline = true, isOn = false)
+        _commissionDeviceStatus.postValue(
+            TaskStatus.Completed("Device added: [${deviceId}] [${deviceName}]"))
       } catch (e: Exception) {
-        Timber.e(e)
+        Timber.e("Adding device [${deviceId}] [${deviceName}] to app's repository failed", e)
+        _commissionDeviceStatus.postValue(
+            TaskStatus.Failed(
+                "Adding device [${deviceId}] [${deviceName}] to app's repository failed", e))
       }
     }
   }

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -191,7 +191,7 @@ constructor(
       val vendorId = intent.getIntExtra("com.google.android.gms.home.matter.EXTRA_VENDOR_ID", -1)
       val productId = intent.getIntExtra("com.google.android.gms.home.matter.EXTRA_PRODUCT_ID", -1)
       val deviceType =
-          intent.getIntExtra("com.google.android.gms.home.matter.EXTRA_DEVICE_Type", -1)
+          intent.getIntExtra("com.google.android.gms.home.matter.EXTRA_DEVICE_TYPE", -1)
       val deviceInfo = DeviceInfo.builder().setProductId(productId).setVendorId(vendorId).build()
       commissionRequestBuilder.setDeviceInfo(deviceInfo)
 
@@ -209,8 +209,9 @@ constructor(
           _commissionDeviceIntentSender.postValue(result)
         }
         .addOnFailureListener { error ->
-          _commissionDeviceStatus.postValue(TaskStatus.Failed(error))
           Timber.e(error)
+          _commissionDeviceStatus.postValue(
+              TaskStatus.Failed("Failed to to get the IntentSender.", error))
         }
   }
   // CODELAB SECTION END
@@ -258,7 +259,7 @@ constructor(
 
   // Called by the fragment in Step 5 of the Device Commissioning flow.
   fun commissionDeviceFailed(message: String) {
-    _commissionDeviceStatus.postValue(TaskStatus.Failed(Throwable(message)))
+    _commissionDeviceStatus.postValue(TaskStatus.Failed(message, Throwable(message)))
   }
 
   /** Updates the status of [commissionDeviceStatus] to success with the given message. */

--- a/app/src/main/res/layout/fragment_new_device.xml
+++ b/app/src/main/res/layout/fragment_new_device.xml
@@ -1,0 +1,45 @@
+<!--
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".screens.home.NewDeviceFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:paddingLeft="30dp"
+        android:paddingRight="30dp">
+        >
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:hint="Device Name"
+            app:endIconMode="clear_text">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/nameTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+</layout>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,4 +92,5 @@
 All of the information will be logged in logcat. Use this command  to only view this sample’s app logs:&lt;p>&lt;i>adb logcat --pid=`adb shell pidof -s homesampleapp`&lt;/i></string>
     <string name="about_app">This app provides downloadable code that shows you how to use Matter APIs in your own Android application.&lt;p>&lt;b>This is not an official Google Home app, it was created as a development tool for sample purposes only.&lt;/b>&lt;p>&lt;i>Google Home Sample Application for Matter&lt;p>Version: %1$s&lt;/i></string>
     <string name="unspecified">Unspecified</string>
+    <string name="error">Error</string>
 </resources>


### PR DESCRIPTION
- Replaced call to chipController.openPairingWindowWithPin with openPairingWindowWithPinCallback. The former did support callback via setCompletionListener().
- Wait for successful completion of "openPairingWindow" before calling the GPS shareDevice() API.
- Cleaned up logs with a standardized "ShareDevice: " prefix for all multi-admin related log messages.
- Fixed error handling and processing of the shareDevice Status LiveData.
- Fixed typo in HomeViewModel: "com.google.android.gms.home.matter.EXTRA_DEVICE_TYPE" (was "com.google.android.gms.home.matter.EXTRA_DEVICE_TYPE").