### PR TITLE
MIsc fixes for 1.2.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdk 27
         targetSdk 31
         versionCode 10
-        versionName "1.2.1"
+        versionName "1.2.2-rc1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -68,6 +68,7 @@ dependencies {
     // Connected Home
     implementation 'com.google.android.gms:play-services-base:18.1.0'
     implementation 'com.google.android.gms:play-services-home:16.0.0-beta1'
+    // fixme implementation 'com.google.android.gms:play-services-home:16.0.0'
 
     // AndroidX
     implementation 'androidx.appcompat:appcompat:1.4.1'

--- a/app/src/main/java/com/google/homesampleapp/GHSAFMApplication.kt
+++ b/app/src/main/java/com/google/homesampleapp/GHSAFMApplication.kt
@@ -31,7 +31,7 @@ class GHSAFMApplication : Application() {
         object : Timber.DebugTree() {
           // Override [log] to add a "global prefix" prefix to the tag.
           override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
-            super.log(priority, "GHSAFM-$tag", message, t)
+            super.log(priority, "${APP_NAME}-$tag", message, t)
           }
 
           // Override [createStackElementTag] to include additional information to the tag.

--- a/app/src/main/java/com/google/homesampleapp/MainActivity.kt
+++ b/app/src/main/java/com/google/homesampleapp/MainActivity.kt
@@ -47,9 +47,13 @@ class MainActivity : AppCompatActivity() {
     // versionName is set in build.gradle.
     val packageInfo = packageManager.getPackageInfo(packageName, 0)
     VERSION_NAME = packageInfo.versionName
+    APP_NAME = getString(R.string.app_name)
+    packageInfo.packageName
     Timber.i(
-        "==============================\nVersion ${VERSION_NAME}\n" +
-            "==============================")
+        "====================================\n" +
+            "Version ${VERSION_NAME}\n" +
+            "App     ${APP_NAME}\n" +
+            "====================================")
 
     // Strings associated with DeviceTypes
     setDeviceTypeStrings(

--- a/app/src/main/java/com/google/homesampleapp/Utils.kt
+++ b/app/src/main/java/com/google/homesampleapp/Utils.kt
@@ -49,7 +49,7 @@ sealed class TaskStatus {
    * The task completed with an exception.
    * @param cause the cause of the failure
    */
-  class Failed(val message: String, val cause: Throwable) : TaskStatus()
+  class Failed(val message: String, val cause: Throwable?) : TaskStatus()
 
   /**
    * The task completed successfully.

--- a/app/src/main/java/com/google/homesampleapp/Utils.kt
+++ b/app/src/main/java/com/google/homesampleapp/Utils.kt
@@ -33,6 +33,7 @@ import timber.log.Timber
 // Various constants
 
 lateinit var VERSION_NAME: String
+lateinit var APP_NAME: String
 
 // -------------------------------------------------------------------------------------------------
 // Display helper functions

--- a/app/src/main/java/com/google/homesampleapp/chip/ClustersHelper.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/ClustersHelper.kt
@@ -296,6 +296,7 @@ class ClustersHelper @Inject constructor(private val chipClient: ChipClient) {
   // -----------------------------------------------------------------------------------------------
   // OnOffCluster functions
 
+  // CODELAB FEATURED BEGIN
   suspend fun toggleDeviceStateOnOffCluster(deviceId: Long, endpoint: Int) {
     Timber.d("toggleDeviceStateOnOffCluster())")
     val connectedDevicePtr =
@@ -319,6 +320,7 @@ class ClustersHelper @Inject constructor(private val chipClient: ChipClient) {
               })
     }
   }
+  // CODELAB FEATURED END
 
   suspend fun setOnOffDeviceStateOnOffCluster(deviceId: Long, isOn: Boolean, endpoint: Int) {
     Timber.d(

--- a/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
+++ b/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
@@ -23,7 +23,6 @@ import com.google.android.gms.home.matter.commissioning.CommissioningCompleteMet
 import com.google.android.gms.home.matter.commissioning.CommissioningRequestMetadata
 import com.google.android.gms.home.matter.commissioning.CommissioningService
 import com.google.homesampleapp.chip.ChipClient
-import com.google.homesampleapp.chip.ClustersHelper
 import com.google.homesampleapp.data.DevicesRepository
 import com.google.homesampleapp.data.DevicesStateRepository
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,7 +45,6 @@ class AppCommissioningService : Service(), CommissioningService.Callback {
   @Inject internal lateinit var devicesRepository: DevicesRepository
   @Inject internal lateinit var devicesStateRepository: DevicesStateRepository
   @Inject internal lateinit var chipClient: ChipClient
-  @Inject internal lateinit var clustersHelper: ClustersHelper
 
   private val serviceJob = Job()
   private val serviceScope = CoroutineScope(Dispatchers.Main + serviceJob)

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
@@ -82,7 +82,7 @@ class DeviceFragment : Fragment() {
   // The fragment's ViewModel.
   private val viewModel: DeviceViewModel by viewModels()
 
-  // The Activity launcher that launches the "shareDevice" activity in Google Play Services.
+  // The ActivityResultLauncher that launches the "shareDevice" activity in Google Play Services.
   private lateinit var shareDeviceLauncher: ActivityResultLauncher<IntentSenderRequest>
 
   // Background work dialog.
@@ -98,8 +98,9 @@ class DeviceFragment : Fragment() {
     super.onCreate(savedInstanceState)
 
     // Share Device Step 1, where an activity launcher is registered.
-    // At step 2, the user triggers the "Share Device" action and the ViewModel calls the
-    // Google Play Services (GPS) API (commissioningClient.shareDevice()).
+    // At step 2 of the "Share Device" flow, the user triggers the "Share Device"
+    // action and the ViewModel calls the Google Play Services (GPS) API
+    // (commissioningClient.shareDevice()).
     // This returns an  IntentSender that is then used in step 3 to call
     // shareDevicelauncher.launch().
     // CODELAB: shareDeviceLauncher definition
@@ -295,11 +296,10 @@ class DeviceFragment : Fragment() {
       }
     }
 
-    // In DeviceSharing step 2, the ViewModel calls the GPS shareDevice() API to get the
-    // IntentSender
-    // to be used with the Android Activity Result API. Once the ViewModel has the IntentSender, it
-    // posts
-    // it via LiveData so the Fragment can use that value to launch the activity (step 3).
+    // In the DeviceSharing flow step 2, the ViewModel calls the GPS shareDevice() API to get the
+    // IntentSender to be used with the Android Activity Result API. Once the ViewModel has
+    // the IntentSender, it posts it via LiveData so the Fragment can use that value to launch the
+    // activity (step 3).
     // Note that when the IntentSender has been processed, it must be consumed to avoid a
     // configuration change that resends the observed values and re-triggers the device sharing.
     // CODELAB FEATURED BEGIN
@@ -307,7 +307,7 @@ class DeviceFragment : Fragment() {
       Timber.d("shareDeviceIntentSender.observe is called with [${intentSenderToString(sender)}]")
       if (sender != null) {
         // Share Device Step 4: Launch the activity described in the IntentSender that
-        // was returned in Step 3 (where the viewModel calls the GPS API to commission
+        // was returned in Step 3 (where the viewModel calls the GPS API to share
         // the device).
         Timber.d("ShareDevice: Launch GPS activity to share device")
         shareDeviceLauncher.launch(IntentSenderRequest.Builder(sender).build())

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
@@ -163,7 +163,9 @@ class DeviceFragment : Fragment() {
     errorAlertDialog =
         MaterialAlertDialogBuilder(requireContext())
             .setPositiveButton(resources.getString(R.string.ok)) { _, _ ->
-              // Nothing to do.
+              // Consume the status so the error panel does not show up again
+              // on a config change.
+              viewModel.consumeShareDeviceStatus()
             }
             .create()
 

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
@@ -148,6 +148,11 @@ constructor(
                       .build())
               .build()
 
+      Timber.d(
+          "ShareDevice: shareDeviceRequest " +
+              "onboardingPayload [${shareDeviceRequest.commissioningWindow.passcode}] " +
+              "discriminator [${shareDeviceRequest.commissioningWindow.discriminator}]")
+
       // The call to shareDevice() creates the IntentSender that will eventually be launched
       // in the fragment to trigger the multi-admin activity in GPS (step 3).
       Matter.getCommissioningClient(activity)
@@ -179,13 +184,15 @@ constructor(
   }
   // CODELAB FEATURED END
 
-  // Called by the fragment when the GPS activity for Device Sharing has completed.
+  // Called by the fragment in Step 5 of the Device Sharing flow when the GPS activity for
+  // Device Sharing has succeeded.
   fun shareDeviceSucceeded(deviceUiModel: DeviceUiModel) {
     _shareDeviceStatus.postValue(TaskStatus.Completed("Device sharing completed successfully"))
     startDevicePeriodicPing(deviceUiModel)
   }
 
-  // Called by the fragment when the GPS activity for Device Sharing has completed.
+  // Called by the fragment in Step 5 of the Device Sharing flow when the GPS activity for
+  // Device Sharing has failed.
   fun shareDeviceFailed(deviceUiModel: DeviceUiModel, resultCode: Int) {
     Timber.d("ShareDevice: Failed with errorCode [${resultCode}]")
     _shareDeviceStatus.postValue(TaskStatus.Failed("Device sharing failed [${resultCode}]", null))

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
@@ -199,6 +199,12 @@ constructor(
     startDevicePeriodicPing(deviceUiModel)
   }
 
+  // Called after we dismiss an error dialog. If we don't consume, a config change redisplays the
+  // alert dialog.
+  fun consumeShareDeviceStatus() {
+    _shareDeviceStatus.postValue(TaskStatus.NotStarted)
+  }
+
   // -----------------------------------------------------------------------------------------------
   // Operations on device
 

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
@@ -168,6 +168,7 @@ constructor(
     }
   }
 
+  // CODELAB FEATURED BEGIN
   /**
    * Consumes the value in [_shareDeviceIntentSender] and sets it back to null. Needs to be called
    * to avoid re-processing an IntentSender after a configuration change where the LiveData is
@@ -176,6 +177,7 @@ constructor(
   fun consumeShareDeviceIntentSender() {
     _shareDeviceIntentSender.postValue(null)
   }
+  // CODELAB FEATURED END
 
   // Called by the fragment when the GPS activity for Device Sharing has completed.
   fun shareDeviceSucceeded(deviceUiModel: DeviceUiModel) {

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
@@ -301,7 +301,7 @@ class HomeFragment : Fragment() {
     errorAlertDialog =
         MaterialAlertDialogBuilder(requireContext())
             .setPositiveButton(resources.getString(R.string.ok)) { _, _ ->
-              // Nothing to do.
+              viewModel.consumeErrorLiveData()
             }
             .create()
   }
@@ -348,7 +348,9 @@ class HomeFragment : Fragment() {
 
     viewModel.errorLiveData.observe(viewLifecycleOwner) { errorInfo ->
       Timber.d("errorLiveData.observe is called with [${errorInfo}]")
-      showAlertDialog(errorAlertDialog, errorInfo.title, errorInfo.message)
+      if (errorInfo != null) {
+        showAlertDialog(errorAlertDialog, errorInfo.title, errorInfo.message)
+      }
     }
   }
 

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
@@ -121,9 +121,9 @@ class HomeFragment : Fragment() {
             viewModel.updateDeviceStateOn(deviceUiModel, onOffSwitch?.isChecked!!)
           })
 
+  // CODELAB: commissionDeviceLauncher declaration
   // The ActivityResult launcher that launches the "commissionDevice" activity in Google Play
   // Services.
-  // CODELAB: commissionDeviceLauncher declaration
   private lateinit var commissionDeviceLauncher: ActivityResultLauncher<IntentSenderRequest>
   // CODELAB SECTION END
 
@@ -315,8 +315,8 @@ class HomeFragment : Fragment() {
       updateUi(devicesUiModel)
     }
 
-    // The current status of the share device action.
     // CODELAB: commissionDeviceStatus
+    // The current status of the share device action.
     viewModel.commissionDeviceStatus.observe(viewLifecycleOwner) { status ->
       Timber.d("commissionDeviceStatus.observe: status [${status}]")
       // TODO: disable the "add device button", update the result text view, etc.
@@ -336,7 +336,7 @@ class HomeFragment : Fragment() {
         // the device).
         Timber.d("CommissionDevice: Launch GPS activity to commission device")
         commissionDeviceLauncher.launch(IntentSenderRequest.Builder(sender).build())
-        // fixme viewModel.consumeCommissionDeviceIntentSender()
+        viewModel.consumeCommissionDeviceIntentSender()
       }
     }
     // CODELAB SECTION END

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
@@ -122,7 +122,7 @@ class HomeFragment : Fragment() {
           })
 
   // CODELAB: commissionDeviceLauncher declaration
-  // The ActivityResult launcher that launches the "commissionDevice" activity in Google Play
+  // The ActivityResultLauncher that launches the "commissionDevice" activity in Google Play
   // Services.
   private lateinit var commissionDeviceLauncher: ActivityResultLauncher<IntentSenderRequest>
   // CODELAB SECTION END
@@ -134,16 +134,17 @@ class HomeFragment : Fragment() {
     super.onCreate(savedInstanceState)
     Timber.d("onCreate bundle is: ${savedInstanceState.toString()}")
 
-    // Commission Device Step 1.
-    // An activity launcher is registered. It will be launched
-    // at steps 2 and 3 when the user triggers the "Add Device" action and the ViewModel
-    // calls the Google Play Services (GPS) API (commissioningClient.commissionDevice()) and returns
-    // returns the IntentSender to be used to launch the proper activity in GPS.
+    // Commission Device Step 1, where An activity launcher is registered.
+    // At step 2 of the "Commission Device" flow, the user triggers the "Commission Device"
+    // action and the ViewModel calls the Google Play Services (GPS) API
+    // (commissioningClient.commissionDevice()).
+    // This returns an  IntentSender that is then used in step 3 to call
+    // commissionDevicelauncher.launch().
     // CODELAB: commissionDeviceLauncher definition
     commissionDeviceLauncher =
         registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
           // Commission Device Step 5.
-          // The Commission Device activity in GPS has completed.
+          // The Commission Device activity in GPS (step 4) has completed.
           val resultCode = result.resultCode
           if (resultCode == Activity.RESULT_OK) {
             Timber.d("CommissionDevice: Success")
@@ -323,9 +324,13 @@ class HomeFragment : Fragment() {
     }
     // CODELAB SECTION END
 
-    // Commission Device Step 2.
-    // The fragment observes the livedata for commissionDeviceIntentSender which
-    // is updated in the ViewModel in step 3 of the Commission Device flow.
+    // In the CommissionDevice flow step 2, the ViewModel calls the GPS commissionDevice() API to
+    // get the
+    // IntentSender to be used with the Android Activity Result API. Once the ViewModel has
+    // the IntentSender, it posts it via LiveData so the Fragment can use that value to launch the
+    // activity (step 3).
+    // Note that when the IntentSender has been processed, it must be consumed to avoid a
+    // configuration change that resends the observed values and re-triggers the commissioning.
     // CODELAB: commissionDeviceIntentSender
     viewModel.commissionDeviceIntentSender.observe(viewLifecycleOwner) { sender ->
       Timber.d(

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -231,9 +231,8 @@ constructor(
   // CODELAB SECTION END
 
   /**
-   * Sample app has been invoked for multi-admin commissionning. FIXME: Can we do it without going
-   * through GMSCore? All I am missing is network location. Currently, it I go through gmscore, it
-   * asks me to scan the QR code. why?
+   * Sample app has been invoked for multi-admin commissionning. TODO: Can we do it without going
+   * through GMSCore? All we're missing is network location.
    */
   fun multiadminCommissioning(intent: Intent, context: Context) {
     Timber.d("multiadminCommissioning: starting")
@@ -299,7 +298,6 @@ constructor(
     Matter.getCommissioningClient(context)
         .commissionDevice(commissioningRequest)
         .addOnSuccessListener { result ->
-          result.describeContents() // FIXME --> what does this show?
           // Communication with fragment is via livedata
           _commissionDeviceStatus.postValue(TaskStatus.InProgress)
           _commissionDeviceIntentSender.postValue(result)
@@ -315,7 +313,7 @@ constructor(
   /**
    * Consumes the value in [_commissionDeviceIntentSender] and sets it back to null. Needs to be
    * called to avoid re-processing the IntentSender after a configuration change (where the LiveData
-   * is re-posted. FIXME: test it
+   * is re-posted.
    */
   fun consumeCommissionDeviceIntentSender() {
     _commissionDeviceIntentSender.postValue(null)
@@ -348,7 +346,7 @@ constructor(
                 .setDateCommissioned(getTimestampForNow())
                 .setVendorId(result.commissionedDeviceDescriptor.vendorId.toString())
                 .setProductId(result.commissionedDeviceDescriptor.productId.toString())
-                // FIXME check this --> I always have unknown
+                // TODO: M5Stack gives deviceType of 0 -> unknown
                 .setDeviceType(
                     convertToAppDeviceType(result.commissionedDeviceDescriptor.deviceType))
                 .build())

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -117,8 +117,8 @@ constructor(
     get() = _commissionDeviceIntentSender
 
   /** An error occurred. Let the fragment know about it. */
-  private val _errorLiveData = MutableLiveData<ErrorInfo>()
-  val errorLiveData: LiveData<ErrorInfo>
+  private val _errorLiveData = MutableLiveData<ErrorInfo?>()
+  val errorLiveData: LiveData<ErrorInfo?>
     get() = _errorLiveData
 
   // The last device id used for devices commissioned on the app's fabric.
@@ -390,6 +390,12 @@ constructor(
         devicesStateRepository.updateDeviceState(deviceUiModel.device.deviceId, true, isOn)
       }
     }
+  }
+
+  // Called after we dismiss an error dialog. If we don't consume, a config change redisplays the
+  // alert dialog.
+  fun consumeErrorLiveData() {
+    _errorLiveData.postValue(null)
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -311,14 +311,16 @@ constructor(
         }
   }
 
+  // CODELAB FEATURED BEGIN
   /**
    * Consumes the value in [_commissionDeviceIntentSender] and sets it back to null. Needs to be
-   * called to re-process the IntentSender after a configuration change where the LiveData is
-   * re-posted.
+   * called to avoid re-processing the IntentSender after a configuration change (where the LiveData
+   * is re-posted. FIXME: test it
    */
   fun consumeCommissionDeviceIntentSender() {
     _commissionDeviceIntentSender.postValue(null)
   }
+  // CODELAB FEATURED END
 
   // Called by the fragment in Step 5 of the Device Commissioning flow.
   fun commissionDeviceSucceeded(activityResult: ActivityResult, deviceName: String) {

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -190,7 +190,7 @@ constructor(
   // back.
 
   /**
-   * Commission Device Step 2. Triggered by the "Commission Device" button in the fragment.
+   * Commission Device Step 2 (part 2). Triggered by the "Commission Device" button in the fragment.
    * Initiates a commission device task. The success callback of the
    * commissioningClient.commissionDevice() API provides the IntentSender to be used to launch the
    * "Commission Device" activity in Google Play Services. This viewModel provides two LiveData
@@ -322,7 +322,8 @@ constructor(
   }
   // CODELAB FEATURED END
 
-  // Called by the fragment in Step 5 of the Device Commissioning flow.
+  // Called by the fragment in Step 5 of the Device Commissioning flow when the GPS activity
+  // for commissioning the device has succeeded.
   fun commissionDeviceSucceeded(activityResult: ActivityResult, deviceName: String) {
     val result =
         CommissioningResult.fromIntentSenderResult(activityResult.resultCode, activityResult.data)
@@ -364,7 +365,8 @@ constructor(
     }
   }
 
-  // Called by the fragment in Step 5 of the Device Commissioning flow.
+  // Called by the fragment in Step 5 of the Device Commissioning flow when the GPS activity for
+  // commissioning the device has failed.
   fun commissionDeviceFailed(resultCode: Int) {
     Timber.d("CommissionDevice: Failed [${resultCode}")
     _commissionDeviceStatus.postValue(


### PR DESCRIPTION
In 1.2.2, we sync the codelab branch and main with Matter 1.0.
- Misc code cleanup.
- The 5 steps of 'commissioning' and 'device sharing' should now be in sync with GoogleHomeMobileSDK.pdf.
- Refactored HomeViewModel:commissionDevice() into commissionDevice() and multiadminCommissioning().
- Added APP_NAME so logs clearly differentiate between GHSAFM and GHSAFM-TC.
- and more...