### PR TITLE
Adds a new developer utility to discover commissionable Matter devices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,16 @@ To clone the repository, complete the following steps:
     $ git clone https://github.com/google-home/sample-app-for-matter-android.git
     ```
 
+## Version
+
+Google Home Sample App for Matter follows the [Semantic](http://semver.org/)
+and [Android](https://developer.android.com/studio/publish/versioning) versioning guidelines for
+release cycle transparency and to maintain backwards compatibility.
+
 ## Releases
 
-There are multiple releases available for this sample app. Before proceding, make sure you
-download the correct one for your use case.
-
-*   **Release [v1.0.3](https://github.com/google-home/sample-app-for-matter-android/releases/tag/v1.0.3)**
-    — Use this release with the [Google Developer Preview](https://developers.home.google.com/matter/get-started).
-*   **Release [v1.1.0](https://github.com/google-home/sample-app-for-matter-android/releases/tag/v1.1.0)**
-    — This release is intended for Google testing use. Do NOT use it with the Google Developer Preview.
-*   **Release [v1.2.0](https://github.com/google-home/sample-app-for-matter-android/releases/tag/v1.2.0)**
-    — This release is intended for Google testing use. Do NOT use it with the Google Developer Preview.  
+Always use the latest release as shown at
+https://github.com/google-home/sample-app-for-matter-android/releases
 
 ## Get started
 
@@ -86,11 +85,14 @@ download the correct one for your use case.
     the [Build an Android App for Matter](https://developers.home.google.com/codelabs/matter-sample-app)
     Codelab.
 
-## Version
+## Issues?
 
-Google Home Sample App for Matter follows the [Semantic](http://semver.org/)
-and [Android](https://developer.android.com/studio/publish/versioning) versioning guidelines for
-release cycle transparency and to maintain backwards compatibility.
+If you run into problems with the sample app, please submit an issue on the 
+[Issues page](https://github.com/google-home/sample-app-for-matter-android/issues).
+
+It is always greatly appreciated if you can try to reproduce the issue you encountered 
+from a clean state as described in document
+["Investigating Issues with the Sample App"](https://github.com/google-home/sample-app-for-matter-android/wiki/How-to-investigate-issues-with-the-sample-app-(GHSAFM)).
 
 ## License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id "org.jetbrains.kotlin.kapt"
     id 'dagger.hilt.android.plugin'
     id "androidx.navigation.safeargs"
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
@@ -18,7 +19,7 @@ android {
         targetSdk 33
         versionCode 12
         versionName "1.2.2"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.google.homesampleapp.CustomTestRunner"
     }
 
     buildTypes {
@@ -59,6 +60,10 @@ android {
             versionNameSuffix = "-targetcommissioner"
         }
     }
+
+    hilt {
+        enableTransformForLocalTests = true
+    }
 }
 
 dependencies {
@@ -93,8 +98,14 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-javalite:3.18.0'
 
     // Hilt
-    kapt 'com.google.dagger:hilt-compiler:2.41'
-    implementation 'com.google.dagger:hilt-android:2.41'
+    // https://dagger.dev/hilt/gradle-setup
+    implementation 'com.google.dagger:hilt-android:2.44.2'
+    implementation 'com.google.ar:core:1.30.0'
+    kapt 'com.google.dagger:hilt-compiler:2.44.2'
+
+    // Hilt For instrumentation tests
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.44.2")
+    kaptAndroidTest 'com.google.dagger:hilt-compiler:2.44.2'
 
     // Other
     implementation 'com.google.android.material:material:1.7.0'
@@ -108,6 +119,10 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.5.1'
     androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+}
+
+kapt {
+    correctErrorTypes true
 }
 
 protobuf {

--- a/app/src/androidTest/java/com/google/homesampleapp/AddDeviceTest.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/AddDeviceTest.kt
@@ -30,6 +30,8 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
 import java.time.Duration
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -50,6 +52,7 @@ import org.junit.runner.RunWith
  */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
+@HiltAndroidTest
 class AddDeviceTest {
 
   private val TEN_SECONDS = Duration.ofSeconds(10).toMillis()
@@ -70,11 +73,14 @@ class AddDeviceTest {
   private lateinit var device: UiDevice
 
   @get:Rule val activityRule = ActivityScenarioRule(MainActivity::class.java)
+  @get:Rule var hiltRule = HiltAndroidRule(this)
 
   @Before
   fun init() {
     // Initialize UiDevice instance
     device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    // Hilt injection.
+    hiltRule.inject()
   }
 
   fun triggerScanForQRCode() {

--- a/app/src/androidTest/java/com/google/homesampleapp/CustomTestRunner.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/CustomTestRunner.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+// A custom runner to set up the instrumented application class for tests.
+// Specified in build.gradle.
+class CustomTestRunner : AndroidJUnitRunner() {
+  override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
+    return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+  }
+}

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/CommissionableFragmentTest.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/CommissionableFragmentTest.kt
@@ -19,7 +19,7 @@ package com.google.homesampleapp.screens.commissionable
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
@@ -60,14 +60,33 @@ class CommissionableFragmentTest {
   // ---------------------------------------------------------------------------
   // Tests support functions
 
-  fun navigateToDiscoverCommissionableDevices() {
-    // Click the Settings icon.
-    onView(withId(R.id.settings)).perform(click())
-    onView(withId(R.id.nested_settings_fragment)).perform(click())
-    // Click on "Developer utilities"
-    onView(ViewMatchers.withText(DEVELOPER_UTILITIES)).perform(click())
-    // Click on "Commissionable devices"
-    onView(ViewMatchers.withText(COMMISSIONABLE_DEVICES)).perform(click())
+  /**
+   * When the app starts, it may or may not display the codelab dialog depending on the state it was
+   * in the last time it was launched. Was unable to find a way to force the preferences datastore
+   * to be cleared prior to the test being run. Having the code below:
+   * ```
+   * @Before fun init() {
+   *   scope.launch {
+   *     userPreferencesRepository.clearData()
+   *   }
+   * }
+   * ```
+   *
+   * does not complete prior to the start of the test.
+   *
+   * So for now, if we fail clicking on "OK" this means the codelab dialog is not shown and we
+   * simplky ignore the exception.
+   *
+   * TODO: If someone knows of a clean way to force a clear of the preferences datastore before the
+   *   test runs, please submit a PR!
+   */
+  private fun clickOkOnCodelabDialog() {
+    try {
+      onView(withText("OK")).perform(click())
+    } catch (e: Throwable) {
+      // The Codelab dialog was not shown. Simply ignore the error.
+      System.out.println("*** Codelab Dialog was not shown.")
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -75,8 +94,17 @@ class CommissionableFragmentTest {
 
   @Test
   fun testFragmentBehavior() {
-    navigateToDiscoverCommissionableDevices()
-    // Let the producers run for 10 seconds, giving the user a chance to verify that all beacons
+    // Click on "OK" of the codelab dialog.
+    // In its own function because the dialog may, or may not be shown and lots of comments
+    // associated with that :-).
+    clickOkOnCodelabDialog()
+    // Click on "Settings"
+    onView(withId(R.id.settings)).perform(click())
+    // Click on "Developer utilities"
+    onView(ViewMatchers.withText(DEVELOPER_UTILITIES)).perform(click())
+    // Click on "Commissionable devices"
+    onView(ViewMatchers.withText(COMMISSIONABLE_DEVICES)).perform(click())
+    // Let the producers run for 60 seconds, giving the user a chance to verify that all beacons
     // are properly shown on screen.
     Thread.sleep(60000)
   }

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/CommissionableFragmentTest.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/CommissionableFragmentTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.google.homesampleapp.MainActivity
+import com.google.homesampleapp.R
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test to verify that Matter beacons are properly shown in CommissionableFragment.
+ *
+ * The test navigates to the "Commissionable devices" screen, and then each beacon producer (BLE,
+ * mDNS, Wi-Fi) emits a beacon at a specific interval. Simply visually inspect that all these
+ * beacons are properly shown on the screen (e.g. proper icon, inactive mDNS services shows with
+ * different color, etc).
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+@HiltAndroidTest
+class CommissionableFragmentTest {
+
+  private val DEVELOPER_UTILITIES = "Developer utilities"
+  private val COMMISSIONABLE_DEVICES = "Commissionable devices"
+
+  @get:Rule val activityRule = ActivityScenarioRule(MainActivity::class.java)
+  @get:Rule var hiltRule = HiltAndroidRule(this)
+
+  @Before
+  fun init() {
+    // Hilt injection.
+    hiltRule.inject()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests support functions
+
+  fun navigateToDiscoverCommissionableDevices() {
+    // Click the Settings icon.
+    onView(withId(R.id.settings)).perform(click())
+    onView(withId(R.id.nested_settings_fragment)).perform(click())
+    // Click on "Developer utilities"
+    onView(ViewMatchers.withText(DEVELOPER_UTILITIES)).perform(click())
+    // Click on "Commissionable devices"
+    onView(ViewMatchers.withText(COMMISSIONABLE_DEVICES)).perform(click())
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+
+  @Test
+  fun testFragmentBehavior() {
+    navigateToDiscoverCommissionableDevices()
+    // Let the producers run for 10 seconds, giving the user a chance to verify that all beacons
+    // are properly shown on screen.
+    Thread.sleep(60000)
+  }
+}

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/ble/MatterBeaconProducerBleFake.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/ble/MatterBeaconProducerBleFake.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import timber.log.Timber
 
-/** [MatterBeaconProducer] which emits mDNS beacons as they are discovered. */
+/** [MatterBeaconProducer] which emits BLE beacons as they are discovered. */
 class MatterBeaconProducerBleFake
 @Inject
 constructor(@ApplicationContext private val context: Context) : MatterBeaconProducer {
@@ -36,7 +36,7 @@ constructor(@ApplicationContext private val context: Context) : MatterBeaconProd
   private val EMIT_DELAY_MS = 1000L
 
   override fun getBeaconsFlow(): Flow<MatterBeacon> = callbackFlow {
-    Timber.d("Starting mDNS discovery -- NATIVE")
+    Timber.d("Starting BLE discovery -- NATIVE")
 
     var count = 0
     while (true) {

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/ble/MatterBeaconProducerBleFake.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/ble/MatterBeaconProducerBleFake.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.ble
+
+import android.content.Context
+import com.google.homesampleapp.screens.commissionable.MatterBeacon
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import com.google.homesampleapp.screens.commissionable.Transport
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
+
+/** [MatterBeaconProducer] which emits mDNS beacons as they are discovered. */
+class MatterBeaconProducerBleFake
+@Inject
+constructor(@ApplicationContext private val context: Context) : MatterBeaconProducer {
+
+  private val EMIT_DELAY_MS = 1000L
+
+  override fun getBeaconsFlow(): Flow<MatterBeacon> = callbackFlow {
+    Timber.d("Starting mDNS discovery -- NATIVE")
+
+    var count = 0
+    while (true) {
+      val beacon =
+          MatterBeacon(
+              name = "BLE-test-${count}",
+              vendorId = 1,
+              productId = 1,
+              discriminator = 1,
+              Transport.Ble("1.1.1.1"))
+
+      trySend(beacon)
+
+      delay(EMIT_DELAY_MS)
+      count++
+    }
+
+    awaitClose { Timber.d("awaitClose: Stop discovery.") }
+  }
+}

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/ble/ModuleBleTest.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/ble/ModuleBleTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.ble
+
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import dagger.multibindings.IntoSet
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [ModuleBle::class])
+internal abstract class ModuleBleTest {
+  @Singleton
+  @Binds
+  @IntoSet
+  abstract fun bindsMatterBeaconProducer(
+      fakeBeacon: MatterBeaconProducerBleFake
+  ): MatterBeaconProducer
+}

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/mdns/MatterBeaconProducerMdnsFake.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/mdns/MatterBeaconProducerMdnsFake.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.mdns
+
+import android.content.Context
+import com.google.homesampleapp.screens.commissionable.MatterBeacon
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import com.google.homesampleapp.screens.commissionable.Transport
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
+
+/** [MatterBeaconProducer] which emits mDNS beacons as they are discovered. */
+class MatterBeaconProducerMdnsFake
+@Inject
+constructor(@ApplicationContext private val context: Context) : MatterBeaconProducer {
+
+  private val EMIT_DELAY_MS = 2000L
+
+  override fun getBeaconsFlow(): Flow<MatterBeacon> = callbackFlow {
+    Timber.d("Starting mDNS discovery -- NATIVE")
+
+    var count = 0
+    while (true) {
+      // Every 4th beacon is for inactive service.
+      val active = (count % 4 != 3)
+      val beacon =
+          MatterBeacon(
+              name = "mDNS-test-${count}",
+              vendorId = 2,
+              productId = 22,
+              discriminator = 222,
+              Transport.Mdns("2.2.2.2", 2, active))
+
+      trySend(beacon)
+
+      delay(EMIT_DELAY_MS)
+      count++
+    }
+
+    awaitClose { Timber.d("awaitClose: Stop discovery.") }
+  }
+}

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/mdns/ModuleMdnsTest.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/mdns/ModuleMdnsTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.mdns
+
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import dagger.multibindings.IntoSet
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [ModuleMdns::class])
+internal abstract class ModuleMdnsTest {
+  @Singleton
+  @Binds
+  @IntoSet
+  abstract fun bindsMatterBeaconProducer(
+      fakeBeacon: MatterBeaconProducerMdnsFake
+  ): MatterBeaconProducer
+}

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/wifi/MatterBeaconProducerWifiFake.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/wifi/MatterBeaconProducerWifiFake.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.wifi
+
+import android.content.Context
+import com.google.homesampleapp.screens.commissionable.MatterBeacon
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import com.google.homesampleapp.screens.commissionable.Transport
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
+
+/** [MatterBeaconProducer] which emits mDNS beacons as they are discovered. */
+class MatterBeaconProducerWifiFake
+@Inject
+constructor(@ApplicationContext private val context: Context) : MatterBeaconProducer {
+
+  private val EMIT_DELAY_MS = 3000L
+
+  override fun getBeaconsFlow(): Flow<MatterBeacon> = callbackFlow {
+    Timber.d("Starting WiFi discovery -- NATIVE")
+
+    var count = 0
+    while (true) {
+      val beacon =
+          MatterBeacon(
+              name = "WiFi-test-${count}",
+              vendorId = 2,
+              productId = 22,
+              discriminator = 222,
+              Transport.Hotspot("SSID"))
+
+      trySend(beacon)
+
+      delay(EMIT_DELAY_MS)
+      count++
+    }
+
+    awaitClose { Timber.d("awaitClose: Stop discovery.") }
+  }
+}

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/wifi/MatterBeaconProducerWifiFake.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/wifi/MatterBeaconProducerWifiFake.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import timber.log.Timber
 
-/** [MatterBeaconProducer] which emits mDNS beacons as they are discovered. */
+/** [MatterBeaconProducer] which emits WiFi beacons as they are discovered. */
 class MatterBeaconProducerWifiFake
 @Inject
 constructor(@ApplicationContext private val context: Context) : MatterBeaconProducer {

--- a/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/wifi/ModuleWifiTest.kt
+++ b/app/src/androidTest/java/com/google/homesampleapp/screens/commissionable/wifi/ModuleWifiTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.wifi
+
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import dagger.multibindings.IntoSet
+import javax.inject.Singleton
+
+@Module
+@TestInstallIn(components = [SingletonComponent::class], replaces = [ModuleWifi::class])
+internal abstract class ModuleWifiTest {
+  @Singleton
+  @Binds
+  @IntoSet
+  abstract fun bindsMatterBeaconProducer(
+      fakeBeacon: MatterBeaconProducerWifiFake
+  ): MatterBeaconProducer
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,14 +19,28 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.homesampleapp">
 
+    <!-- BluetoothLE (BLE) -->
+    <!-- https://developer.android.com/reference/android/bluetooth/le/BluetoothLeScanner#startScan(java.util.List%3Candroid.bluetooth.le.ScanFilter%3E,%20android.bluetooth.le.ScanSettings,%20android.bluetooth.le.ScanCallback)  -->
+    <!-- Android Q (28) or later must have ACCESS_FINE_LOCATION -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        tools:ignore="CoarseFineLocation" />
+    <!-- Needed for <= Build.VERSION_CODES#R (30) (only needed in Manifest) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <!-- Needed for >= Build.VERSION_CODES#S (31) (must be requested) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="true" />
+
+    <!-- Wi-Fi Scan -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
     <!-- TODO: clarify what specifically requires the permission -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
-        tools:ignore="CoarseFineLocation" />
     <uses-permission android:name="android.permission.NFC" />
 
     <application

--- a/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
@@ -29,10 +29,9 @@ import chip.platform.AndroidChipPlatform
 import chip.platform.ChipMdnsCallbackImpl
 import chip.platform.DiagnosticDataProviderImpl
 import chip.platform.NsdManagerServiceBrowser
+import chip.platform.NsdManagerServiceResolver
 import chip.platform.PreferencesConfigurationManager
 import chip.platform.PreferencesKeyValueStoreManager
-import com.google.android.gms.home.matter.Matter
-import com.google.homesampleapp.mdns.GmsCoreServiceResolver
 import com.google.homesampleapp.stripLinkLocalInIpAddress
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -56,7 +55,7 @@ class ChipClient @Inject constructor(@ApplicationContext context: Context) {
         AndroidBleManager(),
         PreferencesKeyValueStoreManager(context),
         PreferencesConfigurationManager(context),
-        GmsCoreServiceResolver(Matter.getDiscoveryClient(context)),
+        NsdManagerServiceResolver(context),
         NsdManagerServiceBrowser(context),
         ChipMdnsCallbackImpl(),
         DiagnosticDataProviderImpl(context))

--- a/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
@@ -19,6 +19,7 @@ package com.google.homesampleapp.chip
 import android.content.Context
 import chip.devicecontroller.ChipDeviceController
 import chip.devicecontroller.ControllerParams
+import chip.devicecontroller.DiscoveredDevice
 import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback
 import chip.devicecontroller.NetworkCredentials
 import chip.devicecontroller.OpenCommissioningCallback
@@ -28,9 +29,10 @@ import chip.platform.AndroidChipPlatform
 import chip.platform.ChipMdnsCallbackImpl
 import chip.platform.DiagnosticDataProviderImpl
 import chip.platform.NsdManagerServiceBrowser
-import chip.platform.NsdManagerServiceResolver
 import chip.platform.PreferencesConfigurationManager
 import chip.platform.PreferencesKeyValueStoreManager
+import com.google.android.gms.home.matter.Matter
+import com.google.homesampleapp.mdns.GmsCoreServiceResolver
 import com.google.homesampleapp.stripLinkLocalInIpAddress
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -54,7 +56,7 @@ class ChipClient @Inject constructor(@ApplicationContext context: Context) {
         AndroidBleManager(),
         PreferencesKeyValueStoreManager(context),
         PreferencesConfigurationManager(context),
-        NsdManagerServiceResolver(context),
+        GmsCoreServiceResolver(Matter.getDiscoveryClient(context)),
         NsdManagerServiceBrowser(context),
         ChipMdnsCallbackImpl(),
         DiagnosticDataProviderImpl(context))
@@ -221,5 +223,18 @@ class ChipClient @Inject constructor(@ApplicationContext context: Context) {
             }
           })
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // We use our own mDNS discovery code, but interesting to note that
+  // ChipDeviceController also offers that feature.
+
+  fun getCommissionableNodes() {
+    chipDeviceController.discoverCommissionableNodes()
+  }
+
+  fun getDiscoveredDevice(index: Int): DiscoveredDevice? {
+    Timber.d("getDiscoveredDevice(${index})")
+    return chipDeviceController.getDiscoveredDevice(index)
   }
 }

--- a/app/src/main/java/com/google/homesampleapp/chip/MatterConstants.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/MatterConstants.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.homesampleapp.chip
 
 object MatterConstants {

--- a/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
+++ b/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
@@ -22,6 +22,7 @@ import android.os.IBinder
 import com.google.android.gms.home.matter.commissioning.CommissioningCompleteMetadata
 import com.google.android.gms.home.matter.commissioning.CommissioningRequestMetadata
 import com.google.android.gms.home.matter.commissioning.CommissioningService
+import com.google.android.gms.home.matter.commissioning.CommissioningService.CommissioningError
 import com.google.homesampleapp.APP_NAME
 import com.google.homesampleapp.R
 import com.google.homesampleapp.chip.ChipClient
@@ -95,15 +96,35 @@ class AppCommissioningService : Service(), CommissioningService.Callback {
     // Perform commissioning on custom fabric for the sample app.
     serviceScope.launch {
       val deviceId = devicesRepository.incrementAndReturnLastDeviceId()
-      Timber.d(
-          "Commissioning: App fabric -> ChipClient.establishPaseConnection(): deviceId [${deviceId}]")
-      chipClient.awaitEstablishPaseConnection(
-          deviceId,
-          metadata.networkLocation.ipAddress.hostAddress!!,
-          metadata.networkLocation.port,
-          metadata.passcode)
-      Timber.d("Commissioning: App fabric -> ChipClient.commissionDevice(): deviceId [${deviceId}]")
-      chipClient.awaitCommissionDevice(deviceId, null)
+      try {
+        Timber.d(
+            "Commissioning: App fabric -> ChipClient.establishPaseConnection(): deviceId [${deviceId}]")
+        chipClient.awaitEstablishPaseConnection(
+            deviceId,
+            metadata.networkLocation.ipAddress.hostAddress!!,
+            metadata.networkLocation.port,
+            metadata.passcode)
+
+        Timber.d(
+            "Commissioning: App fabric -> ChipClient.commissionDevice(): deviceId [${deviceId}]")
+        chipClient.awaitCommissionDevice(deviceId, null)
+      } catch (e: Exception) {
+        Timber.e(e, "onCommissioningRequested() failed")
+        // No way to determine whether this was ATTESTATION_FAILED or DEVICE_UNREACHABLE.
+        commissioningServiceDelegate
+            .sendCommissioningError(CommissioningError.OTHER)
+            .addOnSuccessListener {
+              Timber.d(
+                  "Commissioning: commissioningServiceDelegate.sendCommissioningError() succeeded")
+            }
+            .addOnFailureListener { e2 ->
+              Timber.e(
+                  e2,
+                  "Commissioning: commissioningServiceDelegate.sendCommissioningError() failed",
+                  e2)
+            }
+        return@launch
+      }
 
       Timber.d("Commissioning: Calling commissioningServiceDelegate.sendCommissioningComplete()")
       commissioningServiceDelegate
@@ -111,10 +132,11 @@ class AppCommissioningService : Service(), CommissioningService.Callback {
               CommissioningCompleteMetadata.builder().setToken(deviceId.toString()).build())
           .addOnSuccessListener {
             Timber.d(
-                "Commissioning: OnSuccess for commissioningServiceDelegate.sendCommissioningComplete()")
+                "Commissioning: commissioningServiceDelegate.sendCommissioningComplete() succeeded")
           }
-          .addOnFailureListener { ex ->
-            Timber.e("Commissioning: Failed to send commissioning complete.", ex)
+          .addOnFailureListener { e ->
+            Timber.e(
+                e, "Commissioning: commissioningServiceDelegate.sendCommissioningComplete() failed")
           }
     }
     // CODELAB SECTION END

--- a/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
+++ b/app/src/main/java/com/google/homesampleapp/commissioning/AppCommissioningService.kt
@@ -120,8 +120,7 @@ class AppCommissioningService : Service(), CommissioningService.Callback {
             .addOnFailureListener { e2 ->
               Timber.e(
                   e2,
-                  "Commissioning: commissioningServiceDelegate.sendCommissioningError() failed",
-                  e2)
+                  "Commissioning: commissioningServiceDelegate.sendCommissioningError() failed")
             }
         return@launch
       }

--- a/app/src/main/java/com/google/homesampleapp/mdns/GmsCoreServiceResolver.kt
+++ b/app/src/main/java/com/google/homesampleapp/mdns/GmsCoreServiceResolver.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.mdns
+
+import chip.platform.ChipMdnsCallback
+import chip.platform.ServiceResolver
+import com.google.android.gms.home.matter.discovery.DiscoveryClient
+import com.google.android.gms.home.matter.discovery.ResolveServiceRequest
+import javax.inject.Inject
+import timber.log.Timber
+
+/** mDNS service resolver that leverages the GMSCore mDNS discovery API. */
+class GmsCoreServiceResolver @Inject constructor(private val client: DiscoveryClient) :
+    ServiceResolver {
+  override fun resolve(
+      instanceName: String,
+      serviceType: String,
+      callbackHandle: Long,
+      contextHandle: Long,
+      callback: ChipMdnsCallback
+  ) {
+    client
+        .resolveService(ResolveServiceRequest.create(serviceType, instanceName))
+        .addOnSuccessListener { result ->
+          val serviceInfo = result.serviceInfo
+          Timber.d("GmsCoreServiceResolver:resolveService:success [${serviceInfo}]")
+          Timber.d("txtRecords:")
+          serviceInfo.txtRecords.forEach { txtRecord -> Timber.d(txtRecord.toString()) }
+
+          callback.handleServiceResolve(
+              serviceInfo.instanceName,
+              serviceInfo.serviceType,
+              "fixme-hostName", // TODO
+              serviceInfo.primaryNetworkLocation.ipAddress.hostAddress,
+              serviceInfo.primaryNetworkLocation.port,
+              /* serviceInfo.txtRecords */ null, // TODO
+              callbackHandle,
+              contextHandle,
+          )
+        }
+        .addOnFailureListener { ex ->
+          Timber.d("GmsCoreServiceResolver:resolveService:failure [${ex}]")
+          callback.handleServiceResolve(
+              instanceName,
+              serviceType,
+              /* hostName */ null,
+              /* ipAddress= */ null,
+              /* port= */ 0,
+              /* txtRecords */ null,
+              callbackHandle,
+              contextHandle,
+          )
+        }
+  }
+
+  override fun publish(
+      p0: String?,
+      p1: String?,
+      p2: String?,
+      p3: Int,
+      p4: Array<out String>?,
+      p5: Array<out ByteArray>?,
+      p6: Array<out String>?
+  ) {
+    throw NotImplementedError("Our usage does not involve publishing services.")
+  }
+
+  override fun removeServices() {
+    throw NotImplementedError("Our usage does not involve removing services.")
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/CommissionableFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/CommissionableFragment.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
+import com.google.homesampleapp.R
+import com.google.homesampleapp.databinding.FragmentCommissionableBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Fragment used to display a list of nearby discovered Matter devices (discoverable over BLE,
+ * Wi-Fi, or mDNS).
+ */
+@AndroidEntryPoint
+class CommissionableFragment : Fragment() {
+
+  // Fragment binding.
+  private lateinit var binding: FragmentCommissionableBinding
+
+  // The Fragment's ViewModel
+  private val viewModel: CommissionableViewModel by viewModels()
+
+  // The adapter used by the RecyclerView (where we show the list of devices).
+  private val adapter = MatterBeaconAdapter()
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle functions
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    Timber.d("onCreate()")
+
+    lifecycleScope.launch {
+      lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+        viewModel.beaconsFlow.distinctUntilChanged().collect { beacon ->
+          adapter.submitList(beacon.toList())
+        }
+      }
+    }
+  }
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?
+  ): View {
+    Timber.d("onCreateView()")
+
+    // Setup the binding with the fragment.
+    binding = DataBindingUtil.inflate(inflater, R.layout.fragment_commissionable, container, false)
+
+    // Setup the UI elements
+    setupUiElements()
+
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    Timber.d("onViewCreated()")
+  }
+
+  override fun onResume() {
+    super.onResume()
+    Timber.d("onResume()")
+  }
+
+  // ---------------------------------------------------------------------------
+  // UI Functions
+
+  private fun setupUiElements() {
+    // Click listener when an item is selected in the beacons list.
+    adapter.onBeaconClickedListener =
+        MatterBeaconAdapter.OnBeaconClickedListener { beacon ->
+          // [TODO] Selecting an item in this list could display a screen with detailed information
+          //  about the device, and allow actions on it such as "commissioning".
+          Timber.d("onBeaconClickedListener: beacon [${beacon}]")
+        }
+
+    // RecyclerView
+    binding.listRecyclerView.adapter = adapter
+
+    setupMenu()
+  }
+
+  private fun setupMenu() {
+    // Navigate back
+    binding.topAppBar.setOnClickListener {
+      findNavController().navigate(R.id.action_commissionableFragment_to_homeFragment)
+    }
+
+    binding.topAppBar.setOnMenuItemClickListener {
+      // Navigate to Settings
+      findNavController().navigate(R.id.action_commissionableFragment_to_settingsFragment)
+      true
+    }
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/CommissionableViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/CommissionableViewModel.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.runningFold
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * [ViewModel] which provides a unified view into nearby [MatterBeacon]s as provided by all bound
+ * [MatterBeaconProducer]s in the dependency injection graph.
+ */
+@HiltViewModel
+class gits
+CommissionableViewModel
+@Inject
+constructor(producers: Set<@JvmSuppressWildcards MatterBeaconProducer>) : ViewModel() {
+  /**
+   * Provides a [Flow] representing a live [Set] of nearby [MatterBeacon]s. The set of items will be
+   * amended as more beacons are detected, so can be observed to see the most recently discovered
+   * view.
+   */
+  val beaconsFlow: Flow<Set<MatterBeacon>> =
+      merge(*producers.map { it.getBeaconsFlow() }.toTypedArray())
+          .runningFold(setOf<MatterBeacon>()) { set, item -> set + item }
+          .stateIn(
+              scope = viewModelScope,
+              started = WhileSubscribed(2000),
+              initialValue = emptySet(),
+          )
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/CommissionableViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/CommissionableViewModel.kt
@@ -31,8 +31,7 @@ import kotlinx.coroutines.flow.stateIn
  * [MatterBeaconProducer]s in the dependency injection graph.
  */
 @HiltViewModel
-class gits
-CommissionableViewModel
+class CommissionableViewModel
 @Inject
 constructor(producers: Set<@JvmSuppressWildcards MatterBeaconProducer>) : ViewModel() {
   /**

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeacon.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeacon.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import java.util.*
+
+/**
+ * Representation of a single Matter device beacon.
+ *
+ * @param name a name used to represent the beaconing device
+ * @param vendorId the vendor ID of the beaconing device, or zero if not indicated
+ * @param productId the product ID unique to the vendor ID, if present, or zero if not indicated
+ * @param discriminator the semi-unique discriminator used to identify this beaconing device
+ * @param transport the transport information on which this device was discovered
+ */
+data class MatterBeacon(
+    val name: String,
+    val vendorId: Int,
+    val productId: Int,
+    val discriminator: Int,
+    val transport: Transport,
+) {
+  override fun toString(): String {
+    return String.format(
+        Locale.ROOT,
+        "MatterBeacon([%s] VID=%04X, PID=%04X, Discriminator=%03X, Transport=%s",
+        name,
+        vendorId,
+        productId,
+        discriminator,
+        transport)
+  }
+}
+
+/** Sealed enumeration of supported transports for Matter beacon discovery. */
+sealed class Transport {
+  /**
+   * Bluetooth LE transport.
+   *
+   * @param address the Bluetooth address of the device which was discovered
+   */
+  data class Ble(val address: String) : Transport()
+
+  /**
+   * Wi-Fi hotspot transport.
+   *
+   * @param ssid the Wi-Fi SSID of the device which was discovered
+   */
+  data class Hotspot(val ssid: String) : Transport()
+
+  /**
+   * mDNS transport.
+   *
+   * @param ipAddress the IP address of the device which was discovered
+   * @param port the port at which the service can be reached
+   * @param port whether the service is active or not
+   */
+  data class Mdns(val ipAddress: String, val port: Int, val active: Boolean) : Transport()
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconAdapter.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconAdapter.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.google.homesampleapp.R
+
+/**
+ * Adapter for a MatterBeacon item in the discovery list, which is backed by RecyclerView. The
+ * Adapter creates ViewHolder objects as needed, and also sets the data for those views. The process
+ * of associating views to their data is called binding. See MatterBeaconViewHolder.
+ *
+ * ListAdapter is a RecyclerView.Adapter base class for presenting List data in a RecyclerView,
+ * including computing diffs between Lists on a background thread.
+ */
+class MatterBeaconAdapter() :
+    ListAdapter<MatterBeacon, MatterBeaconViewHolder>(MATTER_BEACON_COMPARATOR) {
+
+  private val delegatingListener =
+      View.OnClickListener {
+        onBeaconClickedListener?.onBeaconClicked(it.getTag(R.id.beacon_tag) as MatterBeacon)
+      }
+
+  /** A listener to be notified when a user clicks a beacon in the list. */
+  var onBeaconClickedListener: OnBeaconClickedListener? = null
+
+  /** Listener interface for list item clicks. */
+  fun interface OnBeaconClickedListener {
+    /** Invoked when the user clicks on a beacon in the list. */
+    fun onBeaconClicked(beacon: MatterBeacon)
+  }
+
+  override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MatterBeaconViewHolder {
+    return MatterBeaconViewHolder.create(parent).apply {
+      itemView.setOnClickListener(delegatingListener)
+    }
+  }
+
+  override fun onBindViewHolder(holder: MatterBeaconViewHolder, position: Int) {
+    holder.bind(getItem(position))
+  }
+
+  companion object {
+    private val MATTER_BEACON_COMPARATOR =
+        object : DiffUtil.ItemCallback<MatterBeacon>() {
+          override fun areItemsTheSame(oldItem: MatterBeacon, newItem: MatterBeacon): Boolean {
+            val retVal = oldItem.name == newItem.name
+            return retVal
+          }
+
+          override fun areContentsTheSame(oldItem: MatterBeacon, newItem: MatterBeacon): Boolean {
+            val retVal = oldItem == newItem
+            return retVal
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconInject.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconInject.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import javax.inject.Qualifier
+
+@Qualifier @Retention(AnnotationRetention.BINARY) annotation class MatterBeaconInject

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconProducer.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconProducer.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import kotlinx.coroutines.flow.Flow
+
+/** Provides a [Flow] of [MatterBeacon]s that can be observed as they are discovered. */
+fun interface MatterBeaconProducer {
+  /** Returns a [Flow] of [MatterBeacon]s that emit devices as they are discovered. */
+  fun getBeaconsFlow(): Flow<MatterBeacon>
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconViewHolder.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/MatterBeaconViewHolder.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.google.homesampleapp.*
+import com.google.homesampleapp.databinding.MatterBeaconViewItemBinding
+import timber.log.Timber
+
+/**
+ * ViewHolder for a MatterBeacon item in the discovered commissionable devices list, which is backed
+ * by RecyclerView. The ViewHolder is a wrapper around a View that contains the layout for an
+ * individual item in the list.
+ *
+ * When the view holder is created, it doesn't have any data associated with it. After the view
+ * holder is created, the RecyclerView binds it to its data. The RecyclerView requests those views,
+ * and binds the views to their data, by calling methods in the adapter (see MatterBeaconsAdapter).
+ */
+class MatterBeaconViewHolder(private val binding: MatterBeaconViewItemBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+  private val addressText: TextView = binding.address
+  private val detailsText: TextView = binding.detail
+  private val iconView: ImageView = binding.icon
+
+  /** Binds the MatterBeacon to the UI element (beacon_view_item.xml) that holds the beacon view. */
+  fun bind(beacon: MatterBeacon) {
+    Timber.d("binding beacon [${beacon}]")
+
+    val icon =
+        when (beacon.transport) {
+          is Transport.Ble -> R.drawable.quantum_gm_ic_bluetooth_vd_theme_24
+          is Transport.Hotspot -> R.drawable.quantum_gm_ic_wifi_vd_theme_24
+          is Transport.Mdns -> R.drawable.quantum_gm_ic_router_vd_theme_24
+        }
+
+    if (beacon.transport is Transport.Mdns) {
+      val active = beacon.transport.active
+      if (!active) {
+        addressText.setTextColor(Color.RED)
+        addressText.text = "[OFF] " + beacon.name
+      } else {
+        addressText.setTextColor(Color.BLACK)
+        addressText.text = beacon.name
+      }
+    } else {
+      addressText.setTextColor(Color.BLACK)
+      addressText.text = beacon.name
+    }
+
+    itemView.setTag(R.id.beacon_tag, beacon)
+    iconView.setImageResource(icon)
+    // addressText.text = beacon.name
+    detailsText.text =
+        detailsText.context.getString(
+            R.string.beacon_detail_text, beacon.vendorId, beacon.productId, beacon.discriminator)
+  }
+
+  companion object {
+    fun create(parent: ViewGroup): MatterBeaconViewHolder {
+      val view =
+          LayoutInflater.from(parent.context)
+              .inflate(R.layout.matter_beacon_view_item, parent, false)
+      val binding = MatterBeaconViewItemBinding.bind(view)
+      return MatterBeaconViewHolder(binding)
+    }
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/ble/MatterBeaconProducerBle.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/ble/MatterBeaconProducerBle.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.ble
+
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.content.Context.BLUETOOTH_SERVICE
+import android.os.ParcelUuid
+import android.os.SystemClock
+import com.google.homesampleapp.screens.commissionable.MatterBeacon
+import com.google.homesampleapp.screens.commissionable.MatterBeaconInject
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import com.google.homesampleapp.screens.commissionable.Transport
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
+
+/** [MatterBeaconProducer] which emits Bluetooth LE beacons as they are discovered. */
+class MatterBeaconProducerBle
+@Inject
+constructor(
+    @MatterBeaconInject private val bluetoothLeScanner: BluetoothLeScanner?,
+    @ApplicationContext private val context: Context,
+) : MatterBeaconProducer {
+
+  // ---------------------------------------------------------------------------
+  // MatterBeaconProducer interface functions
+
+  @SuppressLint("MissingPermission")
+  override fun getBeaconsFlow(): Flow<MatterBeacon> = callbackFlow {
+    val beaconEmittedTime = ConcurrentHashMap<MatterBeacon, Long>()
+
+    val scanCallback =
+        object : ScanCallback() {
+          override fun onScanResult(callbackType: Int, result: ScanResult) {
+            result.toMatterBeaconOrNull()?.let { beacon ->
+              val currentTime = SystemClock.elapsedRealtime()
+              val shouldWeEmitItAgain =
+                  currentTime - (beaconEmittedTime[beacon] ?: 0) > BEACON_EMITTING_DEBOUNCE_IN_MS
+              if (shouldWeEmitItAgain) {
+                beaconEmittedTime[beacon] = currentTime
+                Timber.d("Emitting BLE beacon [${beacon}]")
+                trySend(beacon)
+              }
+            }
+          }
+        }
+
+    if (bluetoothLeScanner != null) {
+      Timber.d("Starting BLE scan.")
+      bluetoothLeScanner.startScan(
+          listOf(
+              ScanFilter.Builder()
+                  .setServiceData(MATTER_UUID, byteArrayOf(0), byteArrayOf(0))
+                  .build()),
+          ScanSettings.Builder()
+              .setScanMode(ScanSettings.SCAN_MODE_BALANCED)
+              .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+              .build(),
+          scanCallback,
+      )
+    } else {
+      Timber.d("BLE Scanner not available.")
+    }
+
+    awaitClose {
+      if (bluetoothLeScanner == null) {
+        Timber.d("BLE Scanner not available.")
+        return@awaitClose
+      }
+
+      val bluetoothAdapter: BluetoothAdapter =
+          (context.getSystemService(BLUETOOTH_SERVICE) as BluetoothManager).adapter
+      if (bluetoothAdapter.state == BluetoothAdapter.STATE_ON) {
+        Timber.d("Stopping BLE scan.")
+        bluetoothLeScanner.stopScan(scanCallback)
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Utility functions
+
+  private fun ScanResult.toMatterBeaconOrNull(): MatterBeacon? {
+    val data = scanRecord?.bytes ?: return null
+    // Full record must be at least 14 bytes.
+    if (data.size < 14) {
+      Timber.d("Dropping BLE ad with record length %d (expected 14)", data.size)
+      return null
+    }
+
+    // Data payload length is byte 4 and should be exactly 10.
+    val dataLength = data[3].toInt()
+    if (dataLength < 10) {
+      Timber.w("Dropping BLE ad with data length [${dataLength}] (expected >= 10)")
+      return null
+    }
+
+    return MatterBeacon(
+        name = device.address,
+        vendorId = ((data[10].toInt() or (data[11].toInt() shl 8)) and 0xFFFF),
+        productId = ((data[12].toInt() or (data[13].toInt() shl 8)) and 0xFFFF),
+        discriminator = ((data[8].toInt() or (data[9].toInt() shl 8)) and 0xFFF),
+        Transport.Ble(device.address))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Companion
+
+  companion object {
+    private val MATTER_UUID = ParcelUuid.fromString("0000FFF6-0000-1000-8000-00805F9B34FB")
+    private const val BEACON_EMITTING_DEBOUNCE_IN_MS = 1000
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/ble/ModuleBle.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/ble/ModuleBle.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.ble
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.le.BluetoothLeScanner
+import android.content.Context
+import com.google.homesampleapp.screens.commissionable.MatterBeaconInject
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+
+/**
+ * If this is instantiated, then all permissions have been cleared and Bluetooth is enabled. See
+ * [SettingsDeveloperUtilitiesNestedFragment].
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class ModuleBle {
+  @Binds
+  @IntoSet
+  abstract fun bindsMatterBeaconProducer(impl: MatterBeaconProducerBle): MatterBeaconProducer
+
+  companion object {
+    @Provides
+    @MatterBeaconInject
+    fun providesBluetoothLeScanner(@ApplicationContext context: Context): BluetoothLeScanner? {
+      return BluetoothAdapter.getDefaultAdapter()?.bluetoothLeScanner
+    }
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/mdns/MatterBeaconProducerMdns.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/mdns/MatterBeaconProducerMdns.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.mdns
+
+import android.content.Context
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import androidx.core.content.ContextCompat.getSystemService
+import com.google.android.gms.home.matter.Matter
+import com.google.android.gms.home.matter.discovery.DnsSdServiceInfo
+import com.google.android.gms.home.matter.discovery.ResolveServiceRequest
+import com.google.android.gms.home.matter.discovery.ResolveServiceRequest.SERVICE_TYPE_COMMISSIONABLE
+import com.google.homesampleapp.chip.ChipClient
+import com.google.homesampleapp.screens.commissionable.MatterBeacon
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import com.google.homesampleapp.screens.commissionable.Transport
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
+
+/** [MatterBeaconProducer] which emits mDNS beacons as they are discovered. */
+class MatterBeaconProducerMdns
+@Inject
+constructor(private val chipClient: ChipClient, @ApplicationContext private val context: Context) :
+    MatterBeaconProducer {
+
+  // Android's NSD Manager. Used to scan mDNS advertisements.
+  private val nsdManager = getSystemService(context, NsdManager::class.java) as NsdManager
+
+  // Google Home Discovery API. See
+  // https://developers.home.google.com/reference/com/google/android/gms/home/matter/discovery/package-summary.
+  private val discoveryClient = Matter.getDiscoveryClient(context)
+
+  // The scanned mDNS beacons list that's currently active.
+  private var beaconsList = mutableListOf<MatterBeacon>()
+
+  // The producer that is set by the flow.
+  private lateinit var producer: ProducerScope<MatterBeacon>
+
+  // ---------------------------------------------------------------------------
+  // DiscoveryListener for NsdManager.discoverServices().
+
+  private val discoveryListener =
+      object : NsdManager.DiscoveryListener {
+
+        // Called as soon as service discovery begins.
+        override fun onDiscoveryStarted(regType: String) {
+          Timber.d("onDiscoveryStarted: regType [${regType}]")
+        }
+
+        override fun onServiceFound(service: NsdServiceInfo) {
+          Timber.d("onServiceFound: service [${service}]")
+          if (service.serviceType != SERVICE_TYPE_ANDROID) {
+            Timber.d(
+                "Discarded Service: Type [${service.serviceType}] Name [${service.serviceName}]")
+          } else {
+            // Resolve the service.
+            val resolveServiceRequest =
+                ResolveServiceRequest.create(service.serviceName, SERVICE_TYPE_COMMISSIONABLE)
+            discoveryClient
+                .resolveService(resolveServiceRequest)
+                .addOnSuccessListener { result ->
+                  Timber.d("resolveService success: [${result.serviceInfo}]")
+                  resolvedDnsSdServiceInfo(result.serviceInfo)
+                }
+                .addOnFailureListener { error ->
+                  Timber.e(error, "resolveService failure: [${error}]")
+                }
+          }
+        }
+
+        override fun onServiceLost(service: NsdServiceInfo) {
+          // When the network service is no longer available.
+          Timber.d("onServiceLost service [${service}]")
+          lostNsdServiceInfo(service)
+        }
+
+        override fun onDiscoveryStopped(serviceType: String) {
+          Timber.d("onDiscoveryStopped serviceType [${serviceType}]")
+        }
+
+        override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+          Timber.d("onStartDiscoveryFailed serviceType [${serviceType}] errorCode [${errorCode}]")
+          nsdManager.stopServiceDiscovery(this)
+        }
+
+        override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
+          Timber.d("onStopDiscoveryFailed serviceType [${serviceType}] errorCode [${errorCode}]")
+          nsdManager.stopServiceDiscovery(this)
+        }
+      }
+
+  // ---------------------------------------------------------------------------
+  // Utility methods to manage the discovered mDNS services.
+
+  /**
+   * The mDNS service has been resolved. We convert the service information into a MatterBeacon and
+   * emit that beacon to the producer flow.
+   */
+  private fun resolvedDnsSdServiceInfo(dnsSdServiceInfo: DnsSdServiceInfo) {
+    val discriminator =
+        dnsSdServiceInfo
+            .getTxtAttributeValue("D")
+            ?.takeIf { it.length <= 4 }
+            ?.takeIf { it.all { char -> char.isDigit() } }
+            ?.toIntOrNull()
+            ?: null
+
+    val vidPid =
+        dnsSdServiceInfo
+            .getTxtAttributeValue("VP")
+            .orEmpty()
+            .split("+")
+            .takeUnless { it.size > 2 }
+            ?.takeIf { it.all { value -> value.all { char -> char.isDigit() } } }
+            ?: null
+
+    val address = dnsSdServiceInfo.networkLocations.get(0).formattedIpAddress
+    val port = dnsSdServiceInfo.networkLocations.get(0).port
+
+    val beacon =
+        MatterBeacon(
+            name = dnsSdServiceInfo.instanceName,
+            vendorId = vidPid?.getOrNull(0)?.toIntOrNull() ?: 0,
+            productId = vidPid?.getOrNull(1)?.toIntOrNull() ?: 0,
+            discriminator = discriminator!!,
+            transport = Transport.Mdns(address, port, true))
+    Timber.d("resolvedDnsSdServiceInfo: [${beacon}]")
+    producer.trySend(beacon)
+  }
+
+  /** The mDNS service is no longer advertising. */
+  private fun lostNsdServiceInfo(nsdServiceInfo: NsdServiceInfo) {
+    Timber.d("lostNsdServiceInfo: [${nsdServiceInfo.serviceName}]")
+    val beacon =
+        MatterBeacon(
+            name = nsdServiceInfo.serviceName,
+            vendorId = 0,
+            productId = 0,
+            discriminator = 0,
+            Transport.Mdns("0.0.0.0", 0 /* fixme */, false))
+    producer.trySend(beacon)
+  }
+
+  // ---------------------------------------------------------------------------
+  // MatterBeaconProducer interface functions
+
+  override fun getBeaconsFlow(): Flow<MatterBeacon> = callbackFlow {
+    Timber.d("Starting mDNS discovery -- NATIVE")
+    producer = this
+    nsdManager.discoverServices(SERVICE_TYPE_ANDROID, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+
+    awaitClose {
+      Timber.d("awaitClose: Stop discovery.")
+      nsdManager.stopServiceDiscovery(discoveryListener)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Companion
+
+  companion object {
+    private const val SERVICE_TYPE_GMSCORE = SERVICE_TYPE_COMMISSIONABLE
+    private const val SERVICE_TYPE_ANDROID = SERVICE_TYPE_GMSCORE + "."
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/mdns/ModuleMdns.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/mdns/ModuleMdns.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.mdns
+
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class ModuleMdns {
+  @Binds
+  @IntoSet
+  abstract fun bindsMatterBeaconProducer(impl: MatterBeaconProducerMdns): MatterBeaconProducer
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/wifi/MatterBeaconProducerWifi.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/wifi/MatterBeaconProducerWifi.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.wifi
+
+import android.annotation.SuppressLint
+import android.net.wifi.ScanResult
+import android.net.wifi.WifiManager
+import com.google.homesampleapp.screens.commissionable.MatterBeacon
+import com.google.homesampleapp.screens.commissionable.MatterBeaconInject
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import com.google.homesampleapp.screens.commissionable.Transport
+import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import timber.log.Timber
+
+private const val SCAN_QUERY_DELAY_MILLIS = 30_000L
+// See section 5.4.2.6 "Using Wi-Fi Temporary Access Points (Soft-AP)" of the Matter Specification.
+private val MATTER_SSID_PATTERN =
+    """MATTER-(\p{XDigit}{3})-(\p{XDigit}{4})-(\p{XDigit}{4})""".toRegex()
+
+/**
+ * [MatterBeaconProducer] that looks for Wi-Fi Soft AP advertisements matching a Matter
+ * commissionable device.
+ *
+ * See these links for important details on Wi-Fi scanning.
+ * - https://developer.android.com/guide/topics/connectivity/wifi-scan
+ * - https://stackoverflow.com/questions/56401057/wifimanager-startscan-deprecated-alternative
+ */
+class MatterBeaconProducerWifi
+@Inject
+constructor(
+    @MatterBeaconInject private val wifiManager: WifiManager,
+) : MatterBeaconProducer {
+  @SuppressLint("MissingPermission")
+  override fun getBeaconsFlow(): Flow<MatterBeacon> = flow {
+    while (coroutineContext.isActive) {
+      val scanResults = wifiManager.scanResults
+      Timber.d("${scanResults.size} results from the wifi scan.")
+      scanResults
+          .orEmpty()
+          .mapNotNull { scanResult -> scanResult.toMatterBeaconOrNull() }
+          .forEach { beacon ->
+            Timber.d("Emitting Matter hotspot beacon: [${beacon}]")
+            emit(beacon)
+          }
+
+      requestScan()
+      delay(SCAN_QUERY_DELAY_MILLIS)
+    }
+  }
+
+  @Suppress("DEPRECATION") // Currently the only option to refresh scan results.
+  private fun requestScan() {
+    // This may stop working in a future Android release, but for now this allows us to refresh the
+    // nearby Wi-Fi SSIDs.
+    wifiManager.startScan()
+  }
+}
+
+private fun ScanResult.toMatterBeaconOrNull(): MatterBeacon? {
+  val ssid = SSID.stripSurroundingQuotes()
+  // TODO when minSdk is 33: val ssid = wifiSsid.toString().stripSurroundingQuotes()
+  return MATTER_SSID_PATTERN.find(ssid)?.let { result ->
+    val (discriminator, vid, pid) = result.destructured
+    MatterBeacon(
+        ssid, vid.toInt(16), pid.toInt(16), discriminator.toInt(16), Transport.Hotspot(ssid))
+  }
+}
+
+private fun String.stripSurroundingQuotes(): String {
+  return if (length > 1 && startsWith("\"") && endsWith("\"")) {
+    substring(1, length - 1)
+  } else {
+    this
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/commissionable/wifi/ModuleWifi.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/commissionable/wifi/ModuleWifi.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.homesampleapp.screens.commissionable.wifi
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import com.google.homesampleapp.screens.commissionable.MatterBeaconInject
+import com.google.homesampleapp.screens.commissionable.MatterBeaconProducer
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class ModuleWifi {
+  @Binds
+  @IntoSet
+  abstract fun bindsMatterBeaconProducer(impl: MatterBeaconProducerWifi): MatterBeaconProducer
+
+  companion object {
+    @Provides
+    @MatterBeaconInject
+    fun providesWifiManager(@ApplicationContext context: Context): WifiManager {
+      return context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    }
+  }
+}

--- a/app/src/main/java/com/google/homesampleapp/screens/settings/SettingsDeveloperUtilitiesNestedFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/settings/SettingsDeveloperUtilitiesNestedFragment.kt
@@ -16,13 +16,21 @@
 
 package com.google.homesampleapp.screens.settings
 
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
@@ -47,9 +55,23 @@ class SettingsDeveloperUtilitiesNestedFragment :
   // The DialogFragment to capture device information when adding dummy device.
   private val dummyDeviceDialogFragment = DummyDeviceDialogFragment()
 
+  private lateinit var scanningPermissionsLauncher: ActivityResultLauncher<Array<String>>
+
   override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
     setPreferencesFromResource(R.xml.settings_developer_utiltities_screen, rootKey)
     preferenceManager.preferenceDataStore = appPreferenceDataStore
+
+    scanningPermissionsLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
+          if (results.values.any { granted -> !granted }) {
+            // TODO --> error dialog and then go back to settings
+            Timber.d("*** scanningPermissionsLauncher: Permissions were not granted.")
+          } else {
+            Timber.d("*** scanningPermissionsLauncher: Permissions were OK!")
+            findNavController()
+                .navigate(R.id.action_settingsDeveloperUtilitiesFragment_to_discoveryFragment)
+          }
+        }
   }
 
   override fun onCreateView(
@@ -64,6 +86,29 @@ class SettingsDeveloperUtilitiesNestedFragment :
   }
 
   private fun setupUiElements() {
+    // Discover commissionable Matter devices.
+    val discoverPreference: Preference? = findPreference("commissionable")
+    discoverPreference?.setOnPreferenceClickListener {
+      Timber.d("discoverPreference onPreferenceClickListener()")
+      logScanningPermissions()
+      if (!allScanningPermissionsGranted()) {
+        Timber.d("All scanning permissions NOT granted. Asking for them.")
+        scanningPermissionsLauncher.launch(getRequiredScanningPermissions())
+        true
+      } else {
+        // Check if Bluetooth is enabled.
+        val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+        if (bluetoothAdapter.isEnabled) {
+          findNavController()
+              .navigate(R.id.action_settingsDeveloperUtilitiesFragment_to_discoveryFragment)
+          true
+        } else {
+          Timber.d("Blutooth is not enabled) --> DISPLAY AN ERROR DIALOG") // FIXME
+          true
+        }
+      }
+    }
+
     // Log Repositories.
     val logReposPreference: Preference? = findPreference("logrepos")
     logReposPreference?.setOnPreferenceClickListener {
@@ -110,5 +155,33 @@ class SettingsDeveloperUtilitiesNestedFragment :
     requireView()
         .findNavController()
         .navigate(R.id.action_settingsDeveloperUtilitiesFragment_to_homeFragment)
+  }
+
+  private fun allScanningPermissionsGranted() =
+      getRequiredScanningPermissions().all {
+        ContextCompat.checkSelfPermission(requireContext(), it) == PackageManager.PERMISSION_GRANTED
+      }
+
+  private fun logScanningPermissions() {
+    val permissions = getRequiredScanningPermissions()
+    permissions.forEach { permission ->
+      Timber.d(
+          "Permission [${permission}] Granted [${ContextCompat.checkSelfPermission(requireContext(), permission) == PackageManager.PERMISSION_GRANTED}]")
+    }
+  }
+
+  private fun getRequiredScanningPermissions(): Array<String> {
+    Timber.d("getRequiredScanningPermissions(): Build.VERSION.SDK_INT is ${Build.VERSION.SDK_INT}")
+    return when {
+      Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
+          arrayOf(
+              Manifest.permission.BLUETOOTH_SCAN,
+              Manifest.permission.ACCESS_FINE_LOCATION,
+          )
+      else ->
+          arrayOf(
+              Manifest.permission.ACCESS_FINE_LOCATION,
+          )
+    }
   }
 }

--- a/app/src/main/res/drawable-v24/quantum_gm_ic_bluetooth_vd_24.xml
+++ b/app/src/main/res/drawable-v24/quantum_gm_ic_bluetooth_vd_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+</vector>

--- a/app/src/main/res/drawable-v24/quantum_gm_ic_bluetooth_vd_theme_24.xml
+++ b/app/src/main/res/drawable-v24/quantum_gm_ic_bluetooth_vd_theme_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17.71,7.71L12,2h-1v7.59L6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 11,14.41L11,22h1l5.71,-5.71 -4.3,-4.29 4.3,-4.29zM13,5.83l1.88,1.88L13,9.59L13,5.83zM14.88,16.29L13,18.17v-3.76l1.88,1.88z"/>
+</vector>

--- a/app/src/main/res/drawable-v24/quantum_gm_ic_router_vd_24.xml
+++ b/app/src/main/res/drawable-v24/quantum_gm_ic_router_vd_24.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-2L17,9h-2v4L5,13c-1.1,0 -2,0.9 -2,2v4c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-4c0,-1.1 -0.9,-2 -2,-2zM19,19L5,19v-4h14v4zM6,16h2v2L6,18zM9.5,16h2v2h-2zM13,16h2v2h-2z"/>
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,7.5c0.69,0 1.32,0.28 1.77,0.73l1.41,-1.41C18.37,6 17.24,5.5 16,5.5s-2.37,0.5 -3.18,1.32l1.41,1.41c0.45,-0.45 1.08,-0.73 1.77,-0.73zM16,4c1.66,0 3.16,0.67 4.24,1.76l1.41,-1.41C20.21,2.9 18.21,2 16,2c-2.21,0 -4.21,0.9 -5.65,2.35l1.41,1.41C12.84,4.67 14.34,4 16,4z"/>
+</vector>

--- a/app/src/main/res/drawable-v24/quantum_gm_ic_router_vd_theme_24.xml
+++ b/app/src/main/res/drawable-v24/quantum_gm_ic_router_vd_theme_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,13h-2L17,9h-2v4L5,13c-1.1,0 -2,0.9 -2,2v4c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2v-4c0,-1.1 -0.9,-2 -2,-2zM19,19L5,19v-4h14v4zM6,16h2v2L6,18zM9.5,16h2v2h-2zM13,16h2v2h-2z"/>
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16,7.5c0.69,0 1.32,0.28 1.77,0.73l1.41,-1.41C18.37,6 17.24,5.5 16,5.5s-2.37,0.5 -3.18,1.32l1.41,1.41c0.45,-0.45 1.08,-0.73 1.77,-0.73zM16,4c1.66,0 3.16,0.67 4.24,1.76l1.41,-1.41C20.21,2.9 18.21,2 16,2c-2.21,0 -4.21,0.9 -5.65,2.35l1.41,1.41C12.84,4.67 14.34,4 16,4z"/>
+</vector>

--- a/app/src/main/res/drawable-v24/quantum_gm_ic_wifi_vd_24.xml
+++ b/app/src/main/res/drawable-v24/quantum_gm_ic_wifi_vd_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,9l2,2c4.97,-4.97 13.03,-4.97 18,0l2,-2C16.93,2.93 7.08,2.93 1,9zM9,17l3,3 3,-3c-1.65,-1.66 -4.34,-1.66 -6,0zM5,13l2,2c2.76,-2.76 7.24,-2.76 10,0l2,-2C15.14,9.14 8.87,9.14 5,13z"/>
+</vector>

--- a/app/src/main/res/drawable-v24/quantum_gm_ic_wifi_vd_theme_24.xml
+++ b/app/src/main/res/drawable-v24/quantum_gm_ic_wifi_vd_theme_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M1,9l2,2c4.97,-4.97 13.03,-4.97 18,0l2,-2C16.93,2.93 7.08,2.93 1,9zM9,17l3,3 3,-3c-1.65,-1.66 -4.34,-1.66 -6,0zM5,13l2,2c2.76,-2.76 7.24,-2.76 10,0l2,-2C15.14,9.14 8.87,9.14 5,13z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_search_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_search_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+</vector>

--- a/app/src/main/res/layout/device_view_item.xml
+++ b/app/src/main/res/layout/device_view_item.xml
@@ -15,9 +15,9 @@
 -->
 
 <RelativeLayout
-    android:id="@+id/root_layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/device_item_shape_off"
@@ -38,7 +38,6 @@
         android:layout_toEndOf="@id/zeicon"
         android:layout_centerVertical="true"
         android:gravity="center_vertical"
-
         android:orientation="vertical">
 
     <TextView
@@ -46,11 +45,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingEnd="16dp"
-        tools:text="Light A"
         android:layout_toEndOf="@id/zeicon"
         android:maxLines="1"
         android:textAppearance="?attr/textAppearanceSubtitle1"
-        android:textColor="@color/mtrl_list_item_tint"/>
+        android:textColor="@color/mtrl_list_item_tint"
+        tools:text="Light A"
+        />
 
     <TextView
         android:id="@+id/zestate"
@@ -60,11 +60,11 @@
         android:layout_toEndOf="@id/zeicon"
         android:paddingEnd="16dp"
         android:maxLines="2"
-        tools:text="Online OFF"
         android:textAppearance="?attr/textAppearanceBody2"
-        android:textColor="@color/mtrl_list_item_tint"/>
+        android:textColor="@color/mtrl_list_item_tint"
+        tools:text="Online OFF"
+        />
     </LinearLayout>
-
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/onoff_switch"

--- a/app/src/main/res/layout/fragment_commissionable.xml
+++ b/app/src/main/res/layout/fragment_commissionable.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".screens.commissionable.CommissionableFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/topBarLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/topAppBar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:title="@string/commissionable_devices"
+                app:menu="@menu/top_app_bar"
+                app:navigationIcon="@drawable/ic_baseline_home_24"/>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/listRecyclerView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:paddingVertical="@dimen/row_item_margin_vertical"
+            android:scrollbars="vertical"
+            app:layoutManager="LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/topBarLayout"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>
+

--- a/app/src/main/res/layout/matter_beacon_view_item.xml
+++ b/app/src/main/res/layout/matter_beacon_view_item.xml
@@ -1,0 +1,74 @@
+<!--
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- Suppressing "Overdraw" as the selectable background is required here. -->
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/device_item_shape_off"
+    android:layout_marginVertical="5dp"
+    android:layout_marginHorizontal="16dp"
+    >
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:paddingHorizontal="16dp"
+        android:importantForAccessibility="no"
+        tools:src="@drawable/quantum_gm_ic_bluetooth_vd_theme_24"
+    />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@id/icon"
+        android:layout_centerVertical="true"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        >
+
+        <TextView
+            android:id="@+id/address"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingEnd="16dp"
+            android:layout_toEndOf="@id/icon"
+            android:maxLines="1"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:textColor="@color/mtrl_list_item_tint"
+            tools:text="CHIP-FA0-1234-5678"
+        />
+
+
+        <TextView
+            android:id="@+id/detail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/address"
+            android:layout_toEndOf="@id/icon"
+            android:paddingEnd="16dp"
+            android:maxLines="2"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:textColor="@color/mtrl_list_item_tint"
+            tools:text="VID: 0x235A PID: 0x0001 Discriminator: 0xFA0"
+        />
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -90,6 +90,9 @@
         <action
             android:id="@+id/action_settingsDeveloperUtilitiesFragment_to_dummyDeviceDialogFragment3"
             app:destination="@id/dummyDeviceDialogFragment3" />
+        <action
+            android:id="@+id/action_settingsDeveloperUtilitiesFragment_to_discoveryFragment"
+            app:destination="@id/commissionableFragment" />
     </fragment>
     <fragment
         android:id="@+id/settingsDeveloperUtilitiesNestedFragment"
@@ -109,4 +112,16 @@
         android:name="com.google.homesampleapp.screens.inspect.InspectFragment"
         android:label="fragment_inspect"
         tools:layout="@layout/fragment_inspect" />
+    <fragment
+        android:id="@+id/commissionableFragment"
+        android:name="com.google.homesampleapp.screens.commissionable.CommissionableFragment"
+        android:label="fragment_commissionable"
+        tools:layout="@layout/fragment_commissionable" >
+        <action
+            android:id="@+id/action_commissionableFragment_to_settingsFragment"
+            app:destination="@id/settingsFragment" />
+        <action
+            android:id="@+id/action_commissionableFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -16,5 +16,5 @@
 -->
 
 <resources>
-    <color name="ic_launcher_background">#3989F9</color>
+    <item name="beacon_tag" type="id" />
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,4 +93,11 @@ All of the information will be logged in logcat. Use this command  to only view 
     <string name="about_app">This app provides downloadable code that shows you how to use Matter APIs in your own Android application.&lt;p>&lt;b>This is not an official Google Home app, it was created as a development tool for sample purposes only.&lt;/b>&lt;p>&lt;i>Google Home Sample Application for Matter&lt;p>Version: %1$s&lt;/i></string>
     <string name="unspecified">Unspecified</string>
     <string name="error">Error</string>
+
+    <!-- Matter Beacon -->
+    <string name="beacon_list_title" translatable="false">Scanning for nearby Matter devices…</string>
+    <string name="beacon_detail_text" translatable="false">VID: 0x%04X PID: 0x%04X Disc: 0x%03X</string>
+    <string name="discovery">Discovery</string>
+    <string name="commissionable_devices">Commissionable Devices</string>
+
 </resources>

--- a/app/src/main/res/xml/settings_developer_utiltities_screen.xml
+++ b/app/src/main/res/xml/settings_developer_utiltities_screen.xml
@@ -20,6 +20,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
         <Preference
+            app:key="commissionable"
+            app:title="Commissionable devices"
+            app:summary="Discover commissionable Matter devices"
+            app:icon="@drawable/ic_baseline_search_24"/>
+
+        <Preference
             app:key="logrepos"
             app:title="Log repositories content"
             app:summary="View in the logs the content of repositories used in the app"

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10"
         classpath 'com.google.protobuf:protobuf-java:3.17.2'
-        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.41'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.42'
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -35,3 +35,4 @@ ext {
     junitVersion = '4.13.2'
     espressoVersion = '3.4.0'
 }
+


### PR DESCRIPTION
- new screen/commissionable package where all that work is implemented.
- Commissionable{Fragment|VewModel} to support the new commissionable screen.
- Set of MatterBeacon* classes provide the infrastructure to support a variety of matter beacons
- Packages ble, mdns, and wifi provide the transport specific scanning code.
- AndroidManifest.xml: New set of permissions for BLE and WiFi scanning.
- ChipClient.kt, GmsCoreServiceResolver.kt: Replaced Android's NsdManagerServiceResolver with one that leverages GMSCore mDNS discovery API.
- Espresso test to verify the behavior of the CommissionableFragment.