### PR TITLE
Add wrappers for readAttributes & subscribeToAttribute

### DIFF
--- a/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
@@ -281,7 +281,7 @@ class ChipClient @Inject constructor(@ApplicationContext context: Context) {
   /**
    * Wrapper around [ChipDeviceController.subscribeToAttributePath]
    */
-  suspend fun subscribeToAttributePath(
+  suspend fun subscribeToAttribute(
       devicePtr: Long,
       attributePath: ChipAttributePath,
       minInterval: Int, maxInterval: Int,

--- a/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/ChipClient.kt
@@ -39,6 +39,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 import timber.log.Timber
+import kotlin.math.max
 
 /** Singleton to interact with the CHIP APIs. */
 @Singleton
@@ -236,35 +237,64 @@ class ChipClient @Inject constructor(@ApplicationContext context: Context) {
     return chipDeviceController.getDiscoveredDevice(index)
   }
 
+  suspend fun readAttribute(
+      devicePtr: Long,
+      attributePath: ChipAttributePath): AttributeState? {
+    return readAttributes(devicePtr, listOf(attributePath))[attributePath];
+  }
+
   /**
    * Wrapper around [ChipDeviceController.readAttributePath]
    */
-  suspend fun readAttributes(devicePtr: Long, attributePaths: List<ChipAttributePath>): Map<ChipAttributePath, AttributeState> {
-      return suspendCoroutine { continuation ->
-          val callback: ReportCallback = object : ReportCallback {
-              override fun onError(
-                  attributePath: ChipAttributePath?,
-                  eventPath: ChipEventPath?,
-                  e: Exception?
-              ) {
-                  continuation.resumeWithException(IllegalStateException("readAttributes failed", e))
-              }
+  suspend fun readAttributes(
+      devicePtr: Long,
+      attributePaths: List<ChipAttributePath>): Map<ChipAttributePath, AttributeState> {
+    return suspendCoroutine { continuation ->
+        val callback: ReportCallback = object : ReportCallback {
+            override fun onError(
+                attributePath: ChipAttributePath?,
+                eventPath: ChipEventPath?,
+                e: Exception?
+            ) {
+                continuation.resumeWithException(IllegalStateException("readAttributes failed", e))
+            }
 
-              override fun onReport(nodeState: NodeState?) {
-                  val states: HashMap<ChipAttributePath, AttributeState> = HashMap<ChipAttributePath, AttributeState> ()
-                  for(path in attributePaths) {
-                      states[path] = nodeState!!.getEndpointState(path.endpointId.id as Int)!!
-                          .getClusterState(path.clusterId.id)!!
-                          .getAttributeState(path.attributeId.id)!!
-                  }
-                  continuation.resume(states);
-              }
+            override fun onReport(nodeState: NodeState?) {
+                val states: HashMap<ChipAttributePath, AttributeState> = HashMap()
+                for(path in attributePaths) {
+                    var endpoint: Int = path.endpointId.id.toInt()
+                    states[path] = nodeState!!.getEndpointState(endpoint)!!
+                        .getClusterState(path.clusterId.id)!!
+                        .getAttributeState(path.attributeId.id)!!
+                }
+                continuation.resume(states);
+            }
 
-              override fun onDone() {
-                  super.onDone()
-              }
-          }
-          chipDeviceController.readAttributePath(callback, devicePtr, attributePaths);
+            override fun onDone() {
+                super.onDone()
+            }
+        }
+        chipDeviceController.readAttributePath(callback, devicePtr, attributePaths);
       }
+  }
+
+  /**
+   * Wrapper around [ChipDeviceController.subscribeToAttributePath]
+   */
+  suspend fun subscribeToAttributePath(
+      devicePtr: Long,
+      attributePath: ChipAttributePath,
+      minInterval: Int, maxInterval: Int,
+      callback: ReportCallback) {
+    return suspendCoroutine { continuation ->
+        chipDeviceController.subscribeToAttributePath(
+            { continuation.resume(Unit) },
+            callback,
+            devicePtr,
+            listOf(attributePath),
+            minInterval,
+            maxInterval
+        )
+    }
   }
 }


### PR DESCRIPTION
Allows to read and subscribe to arbitrary cluster attributes via ChipAttributePath. First step to fully solve issue #76 
Write and invoke need to be added and exposed via JNI on the Chip/Matter side