### PR TITLE
Add support for a DeviceAttestationDelegate

### DIFF
--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
@@ -139,7 +139,10 @@ class HomeFragment : Fragment() {
     super.onCreate(savedInstanceState)
     Timber.d("onCreate bundle is: ${savedInstanceState.toString()}")
 
-    // We need our own device attestation delegate.
+    // We need our own device attestation delegate as we currently only support attestation
+    // of test Matter devices. This DeviceAttestationDelegate makes it possible to ignore device
+    // attestation failures, which happen if commissioning production devices.
+    // TODO: Look into supporting different Root CAs.
     setDeviceAttestationDelegate()
 
     // Commission Device Step 1, where An activity launcher is registered.

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeFragment.kt
@@ -34,12 +34,16 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
+import chip.devicecontroller.AttestationInfo
+import chip.devicecontroller.DeviceAttestationDelegate
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputEditText
 import com.google.homesampleapp.R
 import com.google.homesampleapp.TaskStatus
+import com.google.homesampleapp.chip.ChipClient
 import com.google.homesampleapp.data.DevicesRepository
 import com.google.homesampleapp.data.DevicesStateRepository
 import com.google.homesampleapp.data.UserPreferencesRepository
@@ -53,6 +57,7 @@ import com.google.homesampleapp.screens.shared.UserPreferencesViewModel
 import com.google.homesampleapp.showAlertDialog
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /**
@@ -81,6 +86,7 @@ class HomeFragment : Fragment() {
   @Inject internal lateinit var devicesRepository: DevicesRepository
   @Inject internal lateinit var devicesStateRepository: DevicesStateRepository
   @Inject internal lateinit var userPreferencesRepository: UserPreferencesRepository
+  @Inject internal lateinit var chipClient: ChipClient
 
   // Fragment binding.
   private lateinit var binding: FragmentHomeBinding
@@ -132,6 +138,9 @@ class HomeFragment : Fragment() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     Timber.d("onCreate bundle is: ${savedInstanceState.toString()}")
+
+    // We need our own device attestation delegate.
+    setDeviceAttestationDelegate()
 
     // Commission Device Step 1, where An activity launcher is registered.
     // At step 2 of the "Commission Device" flow, the user triggers the "Commission Device"
@@ -237,6 +246,11 @@ class HomeFragment : Fragment() {
   override fun onStart() {
     super.onStart()
     Timber.d("onStart()")
+  }
+
+  override fun onDestroy() {
+    super.onDestroy()
+    chipClient.chipDeviceController.setDeviceAttestationDelegate(0, EmptyAttestationDelegate())
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -382,5 +396,55 @@ class HomeFragment : Fragment() {
     // Make the hyperlink clickable. Must be set after show().
     val msgTextView: TextView? = codelabInfoAlertDialog.findViewById(android.R.id.message)
     msgTextView?.movementMethod = LinkMovementMethod.getInstance()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Device Attestation Delegate
+
+  private class EmptyAttestationDelegate : DeviceAttestationDelegate {
+    override fun onDeviceAttestationCompleted(
+        devicePtr: Long,
+        attestationInfo: AttestationInfo,
+        errorCode: Int
+    ) {}
+  }
+
+  private fun setDeviceAttestationDelegate() {
+    chipClient.chipDeviceController.setDeviceAttestationDelegate(
+        DEVICE_ATTESTATION_FAILED_TIMEOUT_SECONDS) { devicePtr, attestationInfo, errorCode ->
+          Timber.d(
+              "Device attestation errorCode: $errorCode, " +
+                  "Look at 'src/credentials/attestation_verifier/DeviceAttestationVerifier.h' " +
+                  "AttestationVerificationResult enum to understand the errors")
+
+          if (errorCode == STATUS_PAIRING_SUCCESS) {
+            Timber.d("DeviceAttestationDelegate: Success on device attestation.")
+            lifecycleScope.launch {
+              chipClient.chipDeviceController.continueCommissioning(devicePtr, true)
+            }
+          } else {
+            Timber.d("DeviceAttestationDelegate: Error on device attestation [$errorCode].")
+            // Ideally, we'd want to show a Dialog and ask the user whether the attestation
+            // failure should be ignored or not.
+            // Unfortunately, the GPS commissioning API is in control at this point, and the
+            // Dialog will only show up after GPS gives us back control.
+            // So, we simply ignore the attestation failure for now.
+            // TODO: Add a new setting to control that behavior.
+            Timber.w("Ignoring attestation failure.")
+            lifecycleScope.launch {
+              chipClient.chipDeviceController.continueCommissioning(devicePtr, true)
+            }
+          }
+        }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Companion object
+
+  companion object {
+    private const val STATUS_PAIRING_SUCCESS = 0
+
+    /** Set for the fail-safe timer before onDeviceAttestationFailed is invoked. */
+    private const val DEVICE_ATTESTATION_FAILED_TIMEOUT_SECONDS = 60
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,5 +101,8 @@ All of the information will be logged in logcat. Use this command  to only view 
         Changing the setting for "Halfsheet Notification" will only take effect when the application
         exits and then re-enters the foreground state.
     </string>
-
+    <string name="device_attestation_warning">
+        WARNING: The device attestation failed but was ignored.&lt;p>
+        For details, see &lt;a href="https://github.com/google-home/sample-app-for-matter-android/wiki/Device-Attestation-Failure">Device Attestation Failure&lt;/a>.
+    </string>
 </resources>


### PR DESCRIPTION
With the DeviceAttestationDelegate, device attestation failure is simply ignored. Commissioning non-test Matter devices will now work.

Fix for issues: #83 #86 