### PR TITLE
check and reset the commissioning window before device sharing

### DIFF
--- a/app/src/main/java/com/google/homesampleapp/Utils.kt
+++ b/app/src/main/java/com/google/homesampleapp/Utils.kt
@@ -331,7 +331,17 @@ enum class DeviceIdGenerator {
   Incremental
 }
 
-// Indicates the status of a node's commissioning window
+/**
+ * Indicates the status of a node's commissioning window. Useful in the context of "multi-admin"
+ * when a temporary commissioning window must be open for a target commissioner. That's because
+ * sometimes multi-admin may fail with the target commissioner (especially in a testing environment)
+ * and the temporary commissioning window can then stay open for a substantial amount of time (e.g.
+ * 3 minutes) preventing a new "multi-admin" to fail until that temporary commissioning window is
+ * closed. Checking on the status of the commissioning window beforehand makes it possible to close
+ * the currently open temporary commissioning window before trying to open a new one. [status] is
+ * the enum value returned by reading the WindowStatusAttribute of the "Administrator Commissioning
+ * Cluster". (See spec section "11.18.6.1. CommissioningWindowStatus enum").
+ */
 enum class CommissioningWindowStatus(val status: Int) {
   /** Commissioning window not open */
   WindowNotOpen(0),

--- a/app/src/main/java/com/google/homesampleapp/Utils.kt
+++ b/app/src/main/java/com/google/homesampleapp/Utils.kt
@@ -331,4 +331,16 @@ enum class DeviceIdGenerator {
   Incremental
 }
 
+// Indicates the status of a node's commissioning window
+enum class CommissioningWindowStatus(val status: Int) {
+  /** Commissioning window not open */
+  WindowNotOpen(0),
+
+  /** An Enhanced Commissioning Method window is open */
+  EnhancedWindowOpen(1),
+
+  /** A Basic Commissioning Method window is open */
+  BasicWindowOpen(2)
+}
+
 val OPEN_COMMISSIONING_WINDOW_API = OpenCommissioningWindowApi.ChipDeviceController

--- a/app/src/main/java/com/google/homesampleapp/chip/ClustersHelper.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/ClustersHelper.kt
@@ -535,7 +535,8 @@ class ClustersHelper @Inject constructor(private val chipClient: ChipClient) {
   }
 
   /**
-   * Closes a node's commissioning window.
+   * Closes a node's commissioning window. See spec section "11.18.8.3. RevokeCommissioning
+   * Command".
    *
    * @param devicePtr connected device pointer.
    */
@@ -558,7 +559,8 @@ class ClustersHelper @Inject constructor(private val chipClient: ChipClient) {
   }
 
   /**
-   * Checks if a device has an open commissioning window.
+   * Checks if a device has an open commissioning window. See spec section "11.18.7. Attributes" of
+   * the "Administrator Commissioning Cluster".
    *
    * @param devicePtr connected device pointer.
    * @return true if a window is open, false otherwise.

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
@@ -350,11 +350,26 @@ constructor(
   // -----------------------------------------------------------------------------------------------
   // Open commissioning window
 
-  suspend fun openCommissioningWindowUsingOpenPairingWindowWithPin(deviceId: Long) {
+  private suspend fun openCommissioningWindowUsingOpenPairingWindowWithPin(deviceId: Long) {
     // TODO: Should generate random 64 bit value for SETUP_PIN_CODE (taking into account
     // spec constraints)
     Timber.d("ShareDevice: chipClient.awaitGetConnectedDevicePointer(${deviceId})")
     val connectedDevicePointer = chipClient.awaitGetConnectedDevicePointer(deviceId)
+
+    try {
+      // check if there a commission window that's already open
+      val status = clustersHelper.isCommissioningWindowOpen(connectedDevicePointer)
+      Timber.d("ShareDevice: is commissioning winding open: $status")
+      if (status) {
+        // close commission window
+        clustersHelper.closeCommissioningWindow(connectedDevicePointer)
+      }
+    } catch (ex: Exception) {
+      val errorMsg = "Failed to setup Administrator Commissioning Cluster"
+      Timber.d("$errorMsg. Cause: ${ex.localizedMessage}")
+      // ToDo() decide whether to terminate the OCW task if we fail to configure the window status.
+    }
+
     val duration = OPEN_COMMISSIONING_WINDOW_DURATION_SECONDS
     Timber.d(
         "ShareDevice: chipClient.chipClient.awaitOpenPairingWindowWithPIN " +
@@ -367,7 +382,7 @@ constructor(
 
   // TODO: Was not working when tested. Use openCommissioningWindowUsingOpenPairingWindowWithPin
   // for now.
-  suspend fun openCommissioningWindowWithAdministratorCommissioningCluster(deviceId: Long) {
+  private suspend fun openCommissioningWindowWithAdministratorCommissioningCluster(deviceId: Long) {
     Timber.d(
         "ShareDevice: openCommissioningWindowWithAdministratorCommissioningCluster [${deviceId}]")
     val salt = Random.nextBytes(32)

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceViewModel.kt
@@ -357,10 +357,11 @@ constructor(
     val connectedDevicePointer = chipClient.awaitGetConnectedDevicePointer(deviceId)
 
     try {
-      // check if there a commission window that's already open
-      val status = clustersHelper.isCommissioningWindowOpen(connectedDevicePointer)
-      Timber.d("ShareDevice: is commissioning winding open: $status")
-      if (status) {
+      // Check if there is a commission window that's already open.
+      // See [CommissioningWindowStatus] for complete details.
+      val isOpen = clustersHelper.isCommissioningWindowOpen(connectedDevicePointer)
+      Timber.d("ShareDevice: isCommissioningWindowOpen [$isOpen]")
+      if (isOpen) {
         // close commission window
         clustersHelper.closeCommissioningWindow(connectedDevicePointer)
       }


### PR DESCRIPTION
@pierredelisle  This fixes the `Cluster-specific error: 0x02` thrown when opening a commissioning window while there is one already open.

```log
2023-05-19 16:27:35.910 21598-21629 DMG                     com.google.homesampleapp.default     D  Received Command Response Status for Endpoint=0 Cluster=0x0000_003C Command=0x0000_0000 Status=0x1
2023-05-19 16:27:35.910 21598-21629 CTL                     com.google.homesampleapp.default     E  Failed to open pairing window on the device. Status IM Error 0x00000602: Cluster-specific error: 0x02
2023-05-19 16:27:35.911 21598-21629 GHSAFM-Chi...2$callback com.google.homesampleapp.default     E  ShareDevice: awaitOpenPairingWindowWithPIN.onError: status [1538] device [8078221134675485644]
2023-05-19 16:27:35.911 21598-21629 CTL                     com.google.homesampleapp.default     E  Delete AndroidCommissioningWindowOpener
2023-05-19 16:27:35.911 21598-21629 DMG                     com.google.homesampleapp.default     D  ICR moving to [AwaitingDe]
2023-05-19 16:27:35.911 21598-21629 EM                      com.google.homesampleapp.default     D  <<< [E:2375i S:10813 M:91654183 (Ack:223018962)] (S) Msg TX to 1:701B9B525D62A3CC [B80A] --- Type 0000:10 (SecureChannel:StandaloneAck)
2023-05-19 16:27:35.911 21598-21629 IN                      com.google.homesampleapp.default     D  (S) Sending msg 91654183 on secure session with LSID: 10813
2023-05-19 16:27:35.912 21598-21629 EM                      com.google.homesampleapp.default     D  Flushed pending ack for MessageCounter:223018962 on exchange 2375i
2023-05-19 16:27:35.912 21598-21598 GHSAFM-Dev...hareDevice com.google.homesampleapp.default     D  ShareDevice: Failed to open the commissioning window [java.lang.IllegalStateException: Failed opening the pairing window with status [1538]]
2023-05-19 16:27:36.322 21598-21629 EM                      com.google.homesampleapp.default     D  >>> [E:2375i S:10813 M:223018963 (Ack:91654182)] (S) Msg RX from 1:701B9B525D62A3CC [B80A] --- Type 0000:10 (SecureChannel:StandaloneAck)
```