### PR TITLE
fix remove device navigation

### DIFF
--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
@@ -155,6 +155,13 @@ class DeviceFragment : Fragment() {
     viewModel.stopMonitoringStateChanges()
   }
 
+  override fun onDestroy() {
+    super.onDestroy()
+    // Destroy alert dialogs to avoid leaks
+    errorAlertDialog.dismiss()
+    backgroundWorkAlertDialog.dismiss()
+  }
+
   // -----------------------------------------------------------------------------------------------
   // Setup UI elements
 

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -136,9 +136,11 @@ constructor(
   // The initial setup event which triggers the Home fragment to get the data
   // it needs for its screen.
   // TODO: Clarify if this is really necessary and how that works?
-  val initialSetupEventDevices = liveData { emit(devicesRepository.getAllDevices()) }
-  val initialSetupEventDevicesState = liveData { emit(devicesStateRepository.getAllDevicesState()) }
-  val initialSetupEventUserPreferences = liveData { emit(userPreferencesRepository.getData()) }
+  init {
+    liveData { emit(devicesRepository.getAllDevices()) }
+    liveData { emit(devicesStateRepository.getAllDevicesState()) }
+    liveData { emit(userPreferencesRepository.getData()) }
+  }
 
   private val devicesFlow = devicesRepository.devicesFlow
   private val devicesStateFlow = devicesStateRepository.devicesStateFlow

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -55,7 +55,9 @@
             app:destination="@id/settingsFragment" />
         <action
             android:id="@+id/action_deviceFragment_to_homeFragment"
-            app:destination="@id/homeFragment" />
+            app:destination="@id/homeFragment"
+            app:popUpTo="@+id/deviceFragment"
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_deviceFragment_to_inspectFragment"
             app:destination="@id/inspectFragment" />


### PR DESCRIPTION
@pierredelisle also fix a window leak caused by dialogs in `DeviceFragment.kt`
```shell
2023-05-24 15:58:09.253 30864-30864 WindowManager           com.google.homesampleapp.default     E  android.view.WindowLeaked: Activity com.google.homesampleapp.MainActivity has leaked window DecorView@5d61abc[Unlinking the device] that was originally added here
                                                                                                    	at android.view.ViewRootImpl.<init>(ViewRootImpl.java:733)
                                                                                                    	at android.view.ViewRootImpl.<init>(ViewRootImpl.java:717)
                                                                                                    	at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:399)
                                                                                                    	at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:109)
                                                                                                    	at android.app.Dialog.show(Dialog.java:340)
                                                                                                    	at com.google.homesampleapp.screens.device.DeviceFragment.showBackgroundWorkAlertDialog(DeviceFragment.kt:229)
                                                                                                    	at com.google.homesampleapp.screens.device.DeviceFragment.setupObservers$lambda-12(DeviceFragment.kt:277)
```
and removed unused initialSetupEvent* variables in `HomeViewModel.kt`