### PR TITLE
read and display vendor name and product name

### DIFF
--- a/app/src/main/java/com/google/homesampleapp/chip/ClustersHelper.kt
+++ b/app/src/main/java/com/google/homesampleapp/chip/ClustersHelper.kt
@@ -322,7 +322,8 @@ class ClustersHelper @Inject constructor(private val chipClient: ChipClient) {
   }
 
   /**
-   * Writes NodeLabel attribute
+   * Writes NodeLabel attribute. See spec section "11.1.6.3. Attributes" of the "Basic Information
+   * Cluster".
    *
    * @param deviceId device identifier
    * @param nodeLabel device name/node label
@@ -353,7 +354,72 @@ class ClustersHelper @Inject constructor(private val chipClient: ChipClient) {
   }
 
   /**
-   * Reads NodeLabel attribute
+   * Reads the vendor name attribute. See spec section "11.1.6.3. Attributes" of the "Basic
+   * Information Cluster".
+   *
+   * @param deviceId the device identifier.
+   * @return the vendor name
+   */
+  suspend fun readBasicClusterVendorNameAttribute(deviceId: Long): String {
+    val connectedDevicePtr =
+        try {
+          chipClient.getConnectedDevicePointer(deviceId)
+        } catch (e: IllegalStateException) {
+          Timber.e("Can't get connectedDevicePointer.")
+          return ""
+        }
+
+    return suspendCoroutine { continuation ->
+      val callback =
+          object : ChipClusters.CharStringAttributeCallback {
+            override fun onSuccess(value: String) {
+              continuation.resume(value)
+            }
+
+            override fun onError(ex: Exception) {
+              continuation.resumeWithException(ex)
+            }
+          }
+
+      BasicInformationCluster(connectedDevicePtr, 0).readVendorNameAttribute(callback)
+    }
+  }
+
+  /**
+   * Reads node's product name attribute. See spec section "11.1.6.3. Attributes" of the "Basic
+   * Information Cluster".
+   *
+   * @param deviceId the device identifier
+   * @return the product name
+   */
+  suspend fun readBasicClusterProductNameAttribute(deviceId: Long): String {
+    val connectedDevicePtr =
+        try {
+          chipClient.getConnectedDevicePointer(deviceId)
+        } catch (e: IllegalStateException) {
+          Timber.e("Can't get connectedDevicePointer.")
+          return ""
+        }
+
+    return suspendCoroutine { continuation ->
+      val callback =
+          object : ChipClusters.CharStringAttributeCallback {
+            override fun onSuccess(value: String) {
+              continuation.resume(value)
+            }
+
+            override fun onError(ex: Exception) {
+              continuation.resumeWithException(ex)
+            }
+          }
+
+      BasicInformationCluster(connectedDevicePtr, 0).readProductNameAttribute(callback)
+    }
+  }
+
+  /**
+   * Reads NodeLabel attribute. See spec section "11.1.6.3. Attributes" of the "Basic Information
+   * Cluster".
    *
    * @param deviceId device identifier
    * @return the NodeLabel

--- a/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/device/DeviceFragment.kt
@@ -382,7 +382,9 @@ class DeviceFragment : Fragment() {
               R.string.share_device_info,
               formatTimestamp(deviceUiModel.device.dateCommissioned!!, null),
               deviceUiModel.device.deviceId.toString(),
+              deviceUiModel.device.vendorName,
               deviceUiModel.device.vendorId,
+              deviceUiModel.device.productName,
               deviceUiModel.device.productId,
               deviceUiModel.device.deviceType.displayString())
     }

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -351,6 +351,7 @@ constructor(
             clustersHelper.readBasicClusterVendorNameAttribute(deviceId)
           } catch (ex: Exception) {
             Timber.e(ex, "Failed to read VendorName attribute")
+            ""
           }
 
       val productName =
@@ -358,6 +359,7 @@ constructor(
             clustersHelper.readBasicClusterProductNameAttribute(deviceId)
           } catch (ex: Exception) {
             Timber.e(ex, "Failed to read ProductName attribute")
+            ""
           }
 
       try {
@@ -367,8 +369,10 @@ constructor(
                 .setName(deviceName) // default name that can be overridden by user in next step
                 .setDeviceId(deviceId)
                 .setDateCommissioned(getTimestampForNow())
-                .setVendorId(result.commissionedDeviceDescriptor.vendorId.toString())
-                .setProductId(result.commissionedDeviceDescriptor.productId.toString())
+                .setVendorId(result.commissionedDeviceDescriptor.vendorId)
+                .setVendorName(vendorName)
+                .setProductId(result.commissionedDeviceDescriptor.productId)
+                .setProductName(productName)
                 // Note that deviceType is now deprecated. Need to get it by introspecting
                 // the device information. This is done below.
                 .setDeviceType(

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -369,9 +369,9 @@ constructor(
                 .setName(deviceName) // default name that can be overridden by user in next step
                 .setDeviceId(deviceId)
                 .setDateCommissioned(getTimestampForNow())
-                .setVendorId(result.commissionedDeviceDescriptor.vendorId)
+                .setVendorId(result.commissionedDeviceDescriptor.vendorId.toString())
                 .setVendorName(vendorName)
-                .setProductId(result.commissionedDeviceDescriptor.productId)
+                .setProductId(result.commissionedDeviceDescriptor.productId.toString())
                 .setProductName(productName)
                 // Note that deviceType is now deprecated. Need to get it by introspecting
                 // the device information. This is done below.

--- a/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/google/homesampleapp/screens/home/HomeViewModel.kt
@@ -345,6 +345,21 @@ constructor(
     // Add the device to the devices repository.
     viewModelScope.launch {
       val deviceId = result.token?.toLong()!!
+      // read device's vendor name and product name
+      val vendorName =
+          try {
+            clustersHelper.readBasicClusterVendorNameAttribute(deviceId)
+          } catch (ex: Exception) {
+            Timber.e(ex, "Failed to read VendorName attribute")
+          }
+
+      val productName =
+          try {
+            clustersHelper.readBasicClusterProductNameAttribute(deviceId)
+          } catch (ex: Exception) {
+            Timber.e(ex, "Failed to read ProductName attribute")
+          }
+
       try {
         Timber.d("Commissioning: Adding device to repository")
         devicesRepository.addDevice(

--- a/app/src/main/proto/devices.proto
+++ b/app/src/main/proto/devices.proto
@@ -25,16 +25,10 @@ message Device {
     google.protobuf.Timestamp date_commissioned = 1;
 
     // VID
-    uint32 vendorId = 2;
-
-    // The name of the vendor for the device.
-    string vendorName = 3;
+    string vendorId = 2;
 
     // PID
-    uint32 productId = 4;
-
-    // The name of the model for the device.
-    string productName = 5;
+    string productId = 3;
 
     // Device type.
     enum DeviceType {
@@ -43,19 +37,25 @@ message Device {
         TYPE_LIGHT = 2;
         TYPE_OUTLET = 3;
     }
-    DeviceType deviceType = 6;
+    DeviceType deviceType = 4;
 
     // Device ID within the app's fabric.
-    int64 device_id = 7;
+    int64 device_id = 5;
 
     // Device name.
-    string name = 8;
+    string name = 6;
 
     // Room where device is located.
-    string room = 9;
+    string room = 7;
+
+    // The name of the model for the device.
+    string productName = 8;
+
+    // The name of the vendor for the device.
+    string vendorName = 9;
 }
 
 message Devices {
-  int64 last_device_id = 1;
-  repeated Device devices = 2;
+    int64 last_device_id = 1;
+    repeated Device devices = 2;
 }

--- a/app/src/main/proto/devices.proto
+++ b/app/src/main/proto/devices.proto
@@ -24,9 +24,17 @@ message Device {
     // Timestamp when the device was commissioned.
     google.protobuf.Timestamp date_commissioned = 1;
 
-    // VID / PID
-    string vendorId = 2;
-    string productId = 3;
+    // VID
+    uint32 vendorId = 2;
+
+    // The name of the vendor for the device.
+    string vendorName = 3;
+
+    // PID
+    uint32 productId = 4;
+
+    // The name of the model for the device.
+    string productName = 5;
 
     // Device type.
     enum DeviceType {
@@ -35,16 +43,16 @@ message Device {
         TYPE_LIGHT = 2;
         TYPE_OUTLET = 3;
     }
-    DeviceType deviceType = 4;
+    DeviceType deviceType = 6;
 
     // Device ID within the app's fabric.
-    int64 device_id = 5;
+    int64 device_id = 7;
 
     // Device name.
-    string name = 6;
+    string name = 8;
 
     // Room where device is located.
-    string room = 7;
+    string room = 9;
 }
 
 message Devices {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <!-- Share Device -->
     <string name="share_device_status_success" translatable="false">Share device succeeded</string>
     <string name="share_device_name" translatable="false">Share %1$s</string>
-    <string name="share_device_info" translatable="false">Added on %1$s \nID: %2$s  \nVendor: %3$s (VID:%4$d) \nProduct: %5$s (PID:%6$d)  \nDevice type: %7$s</string>
+    <string name="share_device_info" translatable="false">Added on %1$s \nID: %2$s  \nVendor: %3$s (VID:%4$s) \nProduct: %5$s (PID:%6$s)  \nDevice type: %7$s</string>
 
     <!-- Inspect Device -->
     <string name="inspect_device_name" translatable="false">Inspect %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <!-- Share Device -->
     <string name="share_device_status_success" translatable="false">Share device succeeded</string>
     <string name="share_device_name" translatable="false">Share %1$s</string>
-    <string name="share_device_info" translatable="false">Added on %1$s ID: %2$s  VID: %3$s  PID: %4$s Device type: %5$s</string>
+    <string name="share_device_info" translatable="false">Added on %1$s \nID: %2$s  \nVendor: %3$s (VID:%4$d) \nProduct: %5$s (PID:%6$d)  \nDevice type: %7$s</string>
 
     <!-- Inspect Device -->
     <string name="inspect_device_name" translatable="false">Inspect %1$s</string>


### PR DESCRIPTION
@pierredelisle This reads the `VendorName` and `ProductName` from the **Basic Information Cluster**.  The attribute values are displayed alongside the respective IDs in the `DeviceFragment`.  To some degree, it also resolves https://github.com/google-home/sample-app-for-matter-android/issues/35. 